### PR TITLE
Fix the accessibility defects an audit measured

### DIFF
--- a/layouts/controls.html
+++ b/layouts/controls.html
@@ -146,7 +146,7 @@
   /* The bottom padding is the sheet's, not the grid's: the footer sits outside
      <main> and inside the sheet, so the space that closes the drawing has to
      belong to the thing the registration marks are anchored to. */
-  .sheet { max-width:1200px; margin:0 auto; position:relative;
+  .sheet { max-width:1200px; margin:0 auto; position:relative; overflow-x:clip;
     padding-bottom:128px; }
   @media (min-width:1280px) {
     .sheet { border-inline:1px solid var(--line); }
@@ -177,6 +177,10 @@
   h1 { font-family:var(--head); font-size:clamp(38px,5.5vw,50px);
     font-weight:600; line-height:1.05; margin:0 0 28px; letter-spacing:-0.02em;
     text-wrap:balance; position:relative; }
+  /* 100vw counts the scrollbar, and this rule is centred, so it overhangs the
+     viewport by roughly 4px each side — a constant 8px of horizontal scroll on
+     every width. `clip` rather than `hidden` because `hidden` on an ancestor
+     silently kills position:sticky, which the masthead depends on. */
   h1::after { content:""; position:absolute; z-index:-1; height:1px;
     top:0.79em; left:50%; transform:translateX(-50%); width:100vw;
     background:linear-gradient(to right, transparent 0%,
@@ -190,8 +194,12 @@
     letter-spacing:.1em; text-transform:uppercase;
     color:var(--faint); margin-bottom:3px; }
   dl.tb dd { font-size:13px; margin:0; color:var(--ink);
-    font-variant-numeric:tabular-nums; white-space:nowrap; }
-  dl.tb dd a { color:var(--soft); }
+    font-variant-numeric:tabular-nums; }
+  /* nowrap belongs on the individual links, not the cell. On the cell it made
+     the Reference list one unbreakable run and forced 173px of horizontal
+     scroll on the page at narrow widths — WCAG 1.4.10. Here a link name still
+     never splits, and the list wraps. */
+  dl.tb dd a { color:var(--soft); white-space:nowrap; }
   dl.tb dd a:hover { color:var(--link); }
   @media (max-width:719px) {
     dl.tb { grid-template-columns:1fr 1fr; }
@@ -282,7 +290,7 @@
 
 {{ partial "event-bar.html" . }}
 
-<nav class="utility">
+<nav class="utility" aria-label="Document">
   <div class="in">
     <details class="menu nav-menu">
       <summary aria-label="Site menu">{{ partial "icons/list.svg" . }}</summary>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -104,10 +104,11 @@
      without JS the mast simply never appears, and nothing is lost). Collapsed
      via max-width so the nav links slide rather than jump. */
   .utility a.mast { color:var(--ink); font-weight:600; letter-spacing:.12em; }
-  .utility a.home-mast { max-width:0; opacity:0; overflow:hidden;
+  .utility a.home-mast { max-width:0; opacity:0; visibility:hidden; overflow:hidden;
     white-space:nowrap; margin-right:-18px; padding:0;
     transition:max-width .3s ease, opacity .25s ease, margin-right .3s ease; }
-  .utility.mast-on a.home-mast { max-width:220px; opacity:1; margin-right:0; }
+  .utility.mast-on a.home-mast { max-width:220px; opacity:1; visibility:visible;
+    margin-right:0; }
   @media (prefers-reduced-motion:reduce) {
     .utility a.home-mast { transition:none; }
   }
@@ -168,7 +169,7 @@
   /* The bottom padding is the sheet's, not the grid's: the footer sits outside
      <main> and inside the sheet, so the space that closes the drawing has to
      belong to the thing the registration marks are anchored to. */
-  .sheet { max-width:1200px; margin:0 auto; position:relative;
+  .sheet { max-width:1200px; margin:0 auto; position:relative; overflow-x:clip;
     padding-bottom:128px; }
   @media (min-width:1280px) {
     .sheet { border-inline:1px solid var(--line); }
@@ -307,6 +308,10 @@
      Instrument Serif's ascent) and dissolves toward both margins, so it reads
      as emerging around the type rather than as a section divider. */
   h1 { position:relative; }
+  /* 100vw counts the scrollbar, and this rule is centred, so it overhangs the
+     viewport by roughly 4px each side — a constant 8px of horizontal scroll on
+     every width. `clip` rather than `hidden` because `hidden` on an ancestor
+     silently kills position:sticky, which the masthead depends on. */
   h1::after { content:""; position:absolute; z-index:-1; height:1px;
     top:0.79em; left:50%; transform:translateX(-50%); width:100vw;
     background:linear-gradient(to right, transparent 0%,
@@ -474,7 +479,7 @@
 
 {{ partial "event-bar.html" . }}
 
-<nav class="utility">
+<nav class="utility" aria-label="Document">
   <div class="in">
     <a class="mast home-mast" href="/">Agent Baseline</a>
     <a href="{{ .Site.Params.repo }}">Source</a>

--- a/layouts/partials/event-bar.html
+++ b/layouts/partials/event-bar.html
@@ -43,9 +43,11 @@
   .eventbar .go { color:var(--ink); font-weight:600; text-decoration:none;
     white-space:nowrap; border-bottom:1px solid var(--faint); }
   .eventbar .go:hover { color:var(--accent); border-bottom-color:var(--accent); }
+  /* 24px minimum target — the icon stays 14px, the hit area grows. */
   .eventbar .x { margin-left:auto; flex:none; background:none; border:0;
-    color:var(--faint); cursor:pointer; padding:2px; line-height:0;
-    border-radius:3px; }
+    color:var(--faint); cursor:pointer; padding:5px; line-height:0;
+    border-radius:3px; display:inline-flex; align-items:center;
+    justify-content:center; min-width:24px; min-height:24px; }
   .eventbar .x:hover { color:var(--ink); }
   .eventbar .x:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
   .eventbar[hidden] { display:none; }

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -46,6 +46,14 @@
 @font-face {
   font-family: 'Figtree';
   font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url(/fonts/figtree-normal-400-latin.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Figtree';
+  font-style: normal;
   font-weight: 600;
   font-display: swap;
   src: url(/fonts/figtree-normal-400-latin.woff2) format('woff2');

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -161,6 +161,19 @@
     if (x) {
       var b = bar();
       if (b) {
+        /* Focus is inside the strip at this point. Hiding its ancestor drops
+           the active element to <body>, so a keyboard user loses their place
+           entirely and nothing is announced. Hand focus to the masthead first,
+           which is the next thing in the document. */
+        if (b.contains(document.activeElement)) {
+          var nxt = document.querySelector('.skip, .utility a, main');
+          if (nxt) {
+            if (!nxt.hasAttribute('tabindex') && nxt.tagName === 'MAIN') {
+              nxt.setAttribute('tabindex', '-1');
+            }
+            try { nxt.focus(); } catch (e3) {}
+          }
+        }
         b.hidden = true;
         try { localStorage.setItem('ab-eventbar-' + b.dataset.event, 'off'); } catch (e2) {}
         if (typeof va === 'function') {


### PR DESCRIPTION
From a measured accessibility audit against production. Every number here was measured in a browser, not read off a stylesheet.

## Blocking

**`/controls` scrolled 173px sideways** at narrow widths (WCAG 1.4.10). `white-space: nowrap` sat on the whole datum cell, so the three-link *Reference* list became one unbreakable 367px run — and the narrow-width media query reflowed the grid without ever relaxing the nowrap. Moved onto the links themselves, which is where it was wanted: a link name still never splits, the list wraps.

The residual 8px came from `h1::after { width: 100vw }` on both pages. `100vw` counts the scrollbar and the rule is centred, so it overhung ~4px each side at every width. Clipped on the wrapper — `clip` rather than `hidden`, because `hidden` on an ancestor silently kills the masthead's `position: sticky`.

```
/controls  before: vw 485  sw 658  overflow 173
           after:  vw 485  sw 485  overflow 0
/          after:  vw 485  sw 485  overflow 0
```

## Also fixed

- **`a.home-mast` was focusable while invisible** — collapsed with `max-width:0; opacity:0`, which leaves it in the tab order. Tab stop 3 of 30, focus disappearing into a zero-width element. `visibility:hidden` removes the stop and still transitions.
- **Dismissing the event strip destroyed focus** — it hid the element focus was inside, dropping `activeElement` to `<body>` with nothing announced. Focus now moves to the next landmark first.
- **Figtree 500 was requested and never declared.** The four tenets ask for it, so they rendered at 400 — lighter than authored. Added, pointing at the same variable file as 600 and 700.
- **The dismiss button was an 18×18 tap target** against a 24×24 minimum (WCAG 2.5.8). Hit area grown, icon unchanged.
- **`nav.utility` had no accessible name** on either page, and `/controls` has three navs.

## Deliberately not in this PR

Five accent-on-tint chips **fail contrast in the light theme** — 3.87 to 4.41 against a 4.5 requirement, all of it 10–12px text:

| element | background | ratio |
|---|---|---|
| `ol.questions .a a` | `#E4E4D0` | 3.87 |
| `.meetup .go a` | `#E4E4D0` | 3.87 |
| `.utility a.closes` | `#E7E9D5` | 4.03 |
| `.meetup .lbl` | `#F4F1E8` | 4.41 |
| `.eventbar .tag` | `#F4F1E8` | 4.41 |

The root cause is a single token: `--accent: #5A7A00` is only 4.41:1 on `--wash` *before* any tint, so a self-tinted background has no headroom. Roughly **`#4A6400`** clears all five at once — I verified 5.24:1 on the chip background and 6.3:1 on paper.

That changes the brand accent, so it wants Nick's eye rather than mine. **Dark theme has zero failures anywhere** (accent 12.7–13.8:1).

## Cleared by the same audit

Exactly one `h1` per page, no skipped levels, none empty. All 30 homepage tab stops carry a visible focus ring. CLS 0.0002. Every animation gated behind `prefers-reduced-motion`. `<details>` menus work without JS.
