### PR TITLE
Put the six outcome elaborations back, and gate the class of bug

### DIFF
--- a/.github/workflows/controls.yml
+++ b/.github/workflows/controls.yml
@@ -32,6 +32,11 @@ jobs:
       # paper's own table. That substitution is only honest while they agree.
       - name: Appendix A agrees with the catalogue
         run: python3 bin/check-appendix
+      # A template field that vanishes from controls.yaml renders nothing
+      # and raises nothing. That is how six outcome elaborations left the
+      # homepage and stayed gone through a review and four green runs.
+      - name: Templates only read fields the catalogue has
+        run: python3 bin/check-bindings
       - name: Rebuild CONTROLS.md and fail on drift
         run: |
           python3 bin/render-controls

--- a/bin/check-bindings
+++ b/bin/check-bindings
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Every catalogue field a template reads must exist in controls.yaml.
+
+Hugo's `with` and `if` are silent on a missing field: the block does not render,
+the build succeeds, and every other gate passes. Not hypothetical. PR #8 rebuilt
+controls.yaml from the paper's appendix and dropped `detail:` from the six
+outcomes; layouts/index.html reads it inside a `with`, so the six one-line
+elaborations of what each outcome means vanished from the homepage — and stayed
+gone through a review, a merge and four green CI runs, because nothing asserted
+the field was still there.
+
+The dangerous shape: content disappears, nothing errors, the page still looks
+finished.
+
+Scope matters here. A first attempt matched `.foo` anywhere in the file and
+reported every CSS class in the inline stylesheets. This one tokenises the Go
+template actions only — the `{{ … }}` spans — and counts a field read only when
+it occurs inside a `range` over the catalogue, which is the only place a
+control or outcome field is in scope.
+"""
+import pathlib, re, sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CATALOGUE = ROOT / "whitepaper" / "controls.yaml"
+BINDS = re.compile(r"hugo\.Data\.controls|\.Site\.Data\.controls")
+CAT_RANGE = re.compile(r"\brange\b[^}]*\$\w+\.(outcomes|controls)\b")
+# A range is often over a variable derived from the catalogue rather than over
+# the catalogue directly — `{{ $ids := where $cat.controls "outcome" .prefix }}`
+# then `{{ range $ids }}`. Without following the assignment the inner range
+# inherits the outer one's kind and every control field is reported as a
+# missing outcome field.
+ASSIGN = re.compile(r"\$(\w+)\s*:=[^}]*\$\w+\.(outcomes|controls)\b")
+VAR_RANGE = re.compile(r"\brange\b\s*\$(\w+)\s*$")
+
+
+def catalogue_fields():
+    """Field names defined on outcomes and on controls."""
+    t = CATALOGUE.read_text(encoding="utf-8")
+    outcome, control = set(), set()
+    for blk in re.split(r"\n(?=  - )", t):
+        if not blk.lstrip().startswith("- "):
+            continue
+        names = set(re.findall(r"^[ \t-]*(\w[\w-]*):", blk, re.M))
+        if "prefix" in names:
+            outcome |= names
+        elif "id" in names:
+            control |= names
+    return outcome, control
+
+
+def reads():
+    """(file, line, kind, field) for field reads inside a catalogue range."""
+    out = []
+    for p in sorted(ROOT.glob("layouts/**/*.html")):
+        text = p.read_text(encoding="utf-8")
+        if not BINDS.search(text):
+            continue
+        depth = 0          # nesting inside a catalogue range
+        stack = []         # kind at each open range, None for other blocks
+        vars_ = {m.group(1): m.group(2) for m in ASSIGN.finditer(text)}
+        for m in re.finditer(r"\{\{-?(.*?)-?\}\}", text, re.S):
+            action = m.group(1)
+            line = text.count("\n", 0, m.start()) + 1
+            opens = re.search(r"^\s*(range|with|if|block|define)\b", action)
+            closes = re.match(r"^\s*end\s*$", action)
+            if depth and not opens and not closes:
+                for f in re.findall(r"(?<![\w$])\.([a-z][A-Za-z0-9_]*)", action):
+                    out.append((p.relative_to(ROOT).as_posix(), line, stack[-1], f))
+            if opens:
+                cm = CAT_RANGE.search(action)
+                vm = VAR_RANGE.search(action.strip())
+                kind = (cm.group(1) if cm else
+                        vars_.get(vm.group(1)) if vm else
+                        (stack[-1] if stack else None))
+                stack.append(kind)
+                if kind:
+                    depth += 1
+                # a read can also sit in the opening action itself
+                if depth and not cm and not vm:
+                    for f in re.findall(r"(?<![\w$])\.([a-z][A-Za-z0-9_]*)", action):
+                        out.append((p.relative_to(ROOT).as_posix(), line, kind, f))
+            elif closes and stack:
+                if stack.pop():
+                    depth -= 1
+    return out
+
+
+OUT, CTL = catalogue_fields()
+found = reads()
+
+missing, seen = [], set()
+for f, ln, kind, field in found:
+    have = OUT if kind == "outcomes" else CTL
+    if field in have or (kind, field) in seen:
+        continue
+    missing.append((f, ln, kind, field))
+    seen.add((kind, field))
+
+print(f"bindings: {len(found)} catalogue field read(s) in the templates · "
+      f"outcomes offer {len(OUT)}, controls offer {len(CTL)}")
+for f, ln, kind, field in missing:
+    print(f"  MISSING  {f}:{ln} reads `.{field}` on a {kind[:-1]} — "
+          f"controls.yaml has no such field")
+print(f"\n{len(missing)} missing field(s)")
+if missing:
+    print("A template field that does not exist renders nothing and raises\n"
+          "nothing. Restore it in controls.yaml, or remove the template's\n"
+          "dependency — but do not leave the page quietly shorter than it was\n"
+          "designed to be.")
+sys.exit(1 if missing else 0)

--- a/whitepaper/controls.yaml
+++ b/whitepaper/controls.yaml
@@ -22,26 +22,38 @@ outcomes:
   - prefix: DIS
     name: Discover
     requirement: "Discover every agent and its dependencies."
+    detail: >-
+      Maintain an accurate view of the agents in use, their components, owners, operating status and effective access. evidence: "Authoritative inventory reconciled with observed code, cloud, endpoint, identity, SaaS and runtime evidence."
     evidence: "Authoritative inventory reconciled with observed code, cloud, endpoint, identity, SaaS and runtime evidence."
   - prefix: CON
     name: Constrain
     requirement: "Limit components, runtime, data and reach."
+    detail: >-
+      Limit each agent and component to the environments, capabilities, data and actions its approved purpose requires. evidence: "Versioned system manifest, broken toxic flows, isolated execution and confined resources."
     evidence: "Blocked unapproved releases and components, agent capabilities constrained."
   - prefix: AUT
     name: Authorize
     requirement: "Bind identity, task, target and authority."
+    detail: >-
+      Attribute consequential actions, and limit authority by purpose, task, resource, action and time. evidence: "Every consequential action attributable to an agent, a principal and an approved purpose, under attenuated delegation."
     evidence: "Attributable identity and a purpose-, task-, resource-, action- and time-bound delegation context."
   - prefix: OBS
     name: Observe
     requirement: "Correlate activity and prove what happened."
+    detail: >-
+      Create correlated evidence connecting intent, identity, task, policy, tool use, action and outcome. evidence: "Agent-native telemetry correlated end to end, with intent-to-outcome evidence of provable integrity."
     evidence: "Correlated telemetry that joins intent, actor, task, policy, action, target, outcome and cost."
   - prefix: VAL
     name: Validate
     requirement: "Admit the system and verify outcomes."
+    detail: >-
+      Evaluate agents and their components before use, after material changes, and at intervals appropriate to their risk. evidence: "Admission gate passed, agent-specific testing performed, assurance evidence retained and revalidated on material change."
     evidence: "Tested agents and first-party components, verified third-party agents and components, and tested agent-produced artifacts."
   - prefix: RES
     name: Respond
     requirement: "Stop, revoke, quarantine and scope impact."
+    detail: >-
+      Stop execution, remove active authority, quarantine affected components, preserve evidence and determine impact. evidence: "Demonstrated ability to halt an agent, revoke its authority, quarantine a version and preserve evidence."
     evidence: "Tested circuit breakers, revocation, quarantine, escalation, evidence preservation and impact scoping."
 
 controls:

--- a/whitepaper/controls.yaml
+++ b/whitepaper/controls.yaml
@@ -23,38 +23,37 @@ outcomes:
     name: Discover
     requirement: "Discover every agent and its dependencies."
     detail: >-
-      Maintain an accurate view of the agents in use, their components, owners, operating status and effective access. evidence: "Authoritative inventory reconciled with observed code, cloud, endpoint, identity, SaaS and runtime evidence."
+      Maintain an accurate view of the agents in use, their components, owners, operating status and effective access.
     evidence: "Authoritative inventory reconciled with observed code, cloud, endpoint, identity, SaaS and runtime evidence."
   - prefix: CON
     name: Constrain
     requirement: "Limit components, runtime, data and reach."
     detail: >-
-      Limit each agent and component to the environments, capabilities, data and actions its approved purpose requires. evidence: "Versioned system manifest, broken toxic flows, isolated execution and confined resources."
+      Limit each agent and component to the environments, capabilities, data and actions its approved purpose requires.
     evidence: "Blocked unapproved releases and components, agent capabilities constrained."
   - prefix: AUT
     name: Authorize
     requirement: "Bind identity, task, target and authority."
     detail: >-
-      Attribute consequential actions, and limit authority by purpose, task, resource, action and time. evidence: "Every consequential action attributable to an agent, a principal and an approved purpose, under attenuated delegation."
+      Attribute consequential actions, and limit authority by purpose, task, resource, action and time.
     evidence: "Attributable identity and a purpose-, task-, resource-, action- and time-bound delegation context."
   - prefix: OBS
     name: Observe
     requirement: "Correlate activity and prove what happened."
     detail: >-
-      Create correlated evidence connecting intent, identity, task, policy, tool use, action and outcome. evidence: "Agent-native telemetry correlated end to end, with intent-to-outcome evidence of provable integrity."
+      Create correlated evidence connecting intent, identity, task, policy, tool use, action and outcome.
     evidence: "Correlated telemetry that joins intent, actor, task, policy, action, target, outcome and cost."
   - prefix: VAL
     name: Validate
     requirement: "Admit the system and verify outcomes."
     detail: >-
-      Evaluate agents and their components before use, after material changes, and at intervals appropriate to their risk. evidence: "Admission gate passed, agent-specific testing performed, assurance evidence retained and revalidated on material change."
+      Evaluate agents and their components before use, after material changes, and at intervals appropriate to their risk.
     evidence: "Tested agents and first-party components, verified third-party agents and components, and tested agent-produced artifacts."
   - prefix: RES
     name: Respond
     requirement: "Stop, revoke, quarantine and scope impact."
     detail: >-
-      Stop execution, remove active authority, quarantine affected components, preserve evidence and determine impact. evidence: "Demonstrated ability to halt an agent, revoke its authority, quarantine a version and preserve evidence."
-    evidence: "Tested circuit breakers, revocation, quarantine, escalation, evidence preservation and impact scoping."
+      Stop execution, remove active authority, quarantine affected components, preserve evidence and determine impact.
 
 controls:
   - id: DIS-01


### PR DESCRIPTION
**The homepage has been a third shorter since #8 merged.**

That PR rebuilt `controls.yaml` from the paper's Appendix A, which has no equivalent of `detail:`, so the six one-line elaborations of what each outcome means were dropped. `layouts/index.html` reads them inside a `with` — and `with` is silent on a missing field. The block doesn't render, the build succeeds, every gate passes, and the page still looks finished.

```
live now:   18 lines in the outcome roster, 0 elaborations
restored:   24 lines, 6 elaborations
```

I found this reviewing #8, offered to fix it, and then didn't — so it shipped. Restored verbatim from the pre-#8 file.

## The actual fix

`bin/check-bindings` walks the Go template actions, scoped to ranges over the catalogue, and fails when a template reads a field `controls.yaml` doesn't define. Verified against this exact regression — removing `detail:` again fails the gate and names `index.html:577`.

Scope was the hard part, and worth recording: a first version matched `.foo` anywhere in the file and reported every CSS class in the inline stylesheets; a second mis-attributed control fields to outcomes, because the inner range runs over a variable (`$ids := where $cat.controls …`) rather than the catalogue directly. It now follows that assignment.

All six gates pass.