### PR TITLE
Never let the og:image 404, only ever go stale

### DIFF
--- a/layouts/partials/social-meta.html
+++ b/layouts/partials/social-meta.html
@@ -20,7 +20,19 @@
        has already been fetched. Putting the count in the filename means the URL
        changes exactly when the number does, which is the only thing on the card
        that has ever been wrong. */ -}}
-{{- $card := printf "%ssocial-card-%d.png" .ctx.Site.BaseURL (len hugo.Data.controls.controls) -}}
+{{- /* Versioning the filename by count defeats the platforms' og:image cache,
+       but only bin/build-social writes that file and it never runs in CI — it
+       needs Chrome on a Mac. So the count can move without the image existing,
+       and an og:image that 404s is worse than one showing a stale number: the
+       preview renders blank rather than slightly wrong. Fall back to the
+       unversioned card, which is always present. */ -}}
+{{- $n := len hugo.Data.controls.controls -}}
+{{- $file := printf "social-card-%d.png" $n -}}
+{{- if not (fileExists (printf "static/%s" $file)) -}}
+  {{- warnf "social-card-%d.png is missing — og:image falls back to social-card.png, which may show a stale count. Run bin/build-social." $n -}}
+  {{- $file = "social-card.png" -}}
+{{- end -}}
+{{- $card := printf "%s%s" .ctx.Site.BaseURL $file -}}
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="Agent Baseline">
 <meta property="og:title" content="{{ $t }}">


### PR DESCRIPTION
**A fix I shipped this afternoon made one failure mode worse.** Found by a CI-coverage audit, reproduced before accepting it.

Versioning the card filename by control count defeats the platforms' `og:image` caches — that was the point, and it works. But only `bin/build-social` writes that file, it never runs in CI, and it *cannot*: it needs Chrome at a hardcoded macOS path.

So the count can move without the image existing:

```
# add a 36th control
og:image → https://agentbaseline.org/social-card-36.png
ls static/social-card-36.png → No such file or directory
```

Both pages' `og:image` and `twitter:image` 404. Every Slack, LinkedIn and X unfurl renders blank.

That is strictly worse than the bug it replaced. A stale "33" was cosmetic and self-healing; a 404 is total, and persists until someone on a Mac remembers to run a script.

## Fix

The template falls back to the unversioned card — always present — and warns at build time, naming the missing file and the command that produces it:

```
WARN  social-card-36.png is missing — og:image falls back to social-card.png,
      which may show a stale count. Run bin/build-social.
og:image → https://agentbaseline.org/social-card.png
```

Worst case becomes a preview with a stale number — where we were this morning — instead of no preview at all. Verified in both directions: 35 emits the versioned card, 36 falls back and warns.