### PR TITLE
Never leave a browser running when the print fails

### DIFF
--- a/bin/print-page.mjs
+++ b/bin/print-page.mjs
@@ -13,10 +13,18 @@
  * await its promise, then ask for the PDF. Node's built-in WebSocket means no
  * dependency for any of it.
  *
+ * Driving a browser we spawned means we own its lifetime, and every way out of
+ * this script — success, a failed command, a browser that never came up,
+ * Ctrl-C — has to end with that browser dead. The guards below are for the
+ * ways out that are not the happy one.
+ *
  *   node bin/print-page.mjs <input.html> <output.pdf>
  */
 import { spawn } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { once } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const [input, output] = process.argv.slice(2);
@@ -25,27 +33,103 @@ if (!input || !output) {
   process.exit(2);
 }
 
-const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-const PORT = 9333 + (process.pid % 500);
+// Overridable so the failure paths below can be exercised against a stub
+// browser. The default is the only one this script is expected to drive.
+const CHROME = process.env.CHROME ||
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+// Every wait has a ceiling. An unbounded wait on a browser that has stopped
+// answering does not fail, it hangs — and a hung build never reaches the
+// cleanup that kills the browser.
+const OPEN_MS = 20_000;      // launch to a usable DevTools socket
+const CMD_MS = 30_000;       // an ordinary DevTools command
+const PAGINATE_MS = 180_000; // Paged.js laying out the whole paper
+const PRINT_MS = 120_000;    // printToPDF over 27 pages of embedded fonts
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A profile directory of our own. Chrome writes DevToolsActivePort into it,
+// which is how the port is learned below; because the directory was created a
+// moment ago, the browser answering there is provably the child we spawned.
+// It is also ours to delete — Chrome removes the temporary profile it would
+// otherwise choose for itself only when it exits cleanly, and the shutdown
+// path below is willing to SIGKILL.
+const profile = mkdtempSync(join(tmpdir(), "print-page-"));
 
 const chrome = spawn(CHROME, [
   "--headless", "--disable-gpu", "--no-sandbox",
   "--allow-file-access-from-files",
   "--font-render-hinting=none",
-  `--remote-debugging-port=${PORT}`,
+  `--user-data-dir=${profile}`,
+  // A profile this new otherwise sends Chrome through its first-run work,
+  // which is time spent not listening on the debug port.
+  "--no-first-run", "--no-default-browser-check",
+  // Port 0 asks the OS for a free one. The port used to be derived from this
+  // process's pid, which collides between runs: a browser left behind by an
+  // earlier failure could still hold it, and this script would then drive
+  // *that* browser and kill its own, unrelated, child.
+  "--remote-debugging-port=0",
   "about:blank",
-], { stdio: ["ignore", "ignore", "ignore"] });
+], { stdio: ["ignore", "ignore", "pipe"] });
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// Chrome explains its own startup failures on stderr. Discarding it left
+// bin/build-pdf reporting "PDF FAILED" with two blank lines under it, which is
+// the state this script is most likely to be read in.
+let chromeErr = "";
+chrome.stderr.setEncoding("utf8");
+chrome.stderr.on("data", (d) => { chromeErr = (chromeErr + d).slice(-4000); });
+
+// One rejection standing for every way the browser can stop answering: the
+// socket closing, an error on it, or the child exiting. Without it a command
+// in flight when the browser dies never settles at all — the process hangs
+// with the browser still running, and nothing after the await ever executes.
+let abort;
+const gone = new Promise((_, reject) => { abort = reject; });
+gone.catch(() => {}); // always raced against, never awaited alone
+
+let chromeGone = null;
+chrome.on("exit", (code, signal) => {
+  chromeGone ??= new Error(`Chrome exited (${signal ? `signal ${signal}` : `code ${code}`})`);
+  abort(chromeGone);
+});
+chrome.on("error", (e) => {
+  chromeGone ??= new Error(`could not start Chrome at ${CHROME}: ${e.message}`);
+  abort(chromeGone);
+});
+
+function deadline(promise, ms, what) {
+  let timer;
+  const expiry = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${what} (waited ${ms}ms)`)), ms);
+  });
+  return Promise.race([promise, gone, expiry]).finally(() => clearTimeout(timer));
+}
+
+const ACTIVE_PORT = join(profile, "DevToolsActivePort");
 
 async function endpoint() {
-  for (let i = 0; i < 100; i++) {
+  const until = Date.now() + OPEN_MS;
+  while (Date.now() < until) {
+    // Re-checked every pass rather than waited out: a browser that has already
+    // exited is never going to write the file, and there is no reason to spend
+    // the whole timeout discovering that.
+    if (chromeGone) throw chromeGone;
+    let port = null;
     try {
-      const r = await fetch(`http://127.0.0.1:${PORT}/json/list`);
-      const tabs = await r.json();
-      const page = tabs.find((t) => t.type === "page");
-      if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl;
-    } catch { /* not up yet */ }
+      // Chrome writes the port, then the browser target path. One line means
+      // the file was caught half-written.
+      const lines = readFileSync(ACTIVE_PORT, "utf8").split("\n");
+      if (lines.length >= 2 && /^\d+$/.test(lines[0])) port = Number(lines[0]);
+    } catch { /* not written yet */ }
+    if (port) {
+      try {
+        const r = await fetch(`http://127.0.0.1:${port}/json/list`,
+                              { signal: AbortSignal.timeout(2000) });
+        const tabs = await r.json();
+        const page = tabs.find((t) => t.type === "page");
+        if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl;
+      } catch { /* listening, no page target yet */ }
+    }
     await sleep(100);
   }
   throw new Error("Chrome did not expose a DevTools endpoint");
@@ -55,35 +139,75 @@ let id = 0;
 const pending = new Map();
 const waiters = [];
 
-function send(ws, method, params = {}) {
+function send(ws, method, params = {}, ms = CMD_MS) {
   const msg = { id: ++id, method, params };
-  return new Promise((resolve, reject) => {
+  const reply = new Promise((resolve, reject) => {
     pending.set(msg.id, { resolve, reject });
     ws.send(JSON.stringify(msg));
   });
+  return deadline(reply, ms, `${method} did not answer`)
+    .finally(() => pending.delete(msg.id));
 }
 
-function waitFor(method) {
-  return new Promise((resolve) => waiters.push({ method, resolve }));
+function waitFor(method, ms = CMD_MS) {
+  const entry = { method };
+  const event = new Promise((resolve) => { entry.resolve = resolve; waiters.push(entry); });
+  return deadline(event, ms, `${method} never fired`).finally(() => {
+    const i = waiters.indexOf(entry);
+    if (i >= 0) waiters.splice(i, 1);
+  });
 }
 
-const ws = new WebSocket(await endpoint());
-await new Promise((r) => (ws.onopen = r));
+async function shutdown() {
+  if (chrome.exitCode !== null || chrome.signalCode !== null) return;
+  chrome.kill("SIGTERM");
+  // SIGTERM lets Chrome flush and release its own locks. A browser wedged
+  // badly enough to be the reason we are unwinding may not answer it, and a
+  // browser left running is the whole defect this function exists to close,
+  // so give it a moment and then stop asking.
+  const exited = await Promise.race([once(chrome, "exit").then(() => true), sleep(3000)]);
+  if (exited !== true) chrome.kill("SIGKILL");
+}
 
-ws.onmessage = (e) => {
-  const m = JSON.parse(e.data);
-  if (m.id && pending.has(m.id)) {
-    const { resolve, reject } = pending.get(m.id);
-    pending.delete(m.id);
-    m.error ? reject(new Error(m.error.message)) : resolve(m.result);
-  } else if (m.method) {
-    for (let i = waiters.length - 1; i >= 0; i--) {
-      if (waiters[i].method === m.method) { waiters[i].resolve(m.params); waiters.splice(i, 1); }
-    }
-  }
-};
+// Ctrl-C during a build is the same leak by another route: without this the
+// script dies and the browser it spawned does not.
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.once(sig, async () => {
+    await shutdown();
+    rmSync(profile, { recursive: true, force: true });
+    process.exit(130);
+  });
+}
 
+let ws = null;
+// Finding the endpoint and opening the socket are inside the try now. They
+// used to sit above it, so a browser that started and never opened a debug
+// port was left running: the block that owns chrome.kill() had not been
+// entered yet when the wait gave up.
 try {
+  ws = new WebSocket(await endpoint());
+  // Registered before the open is awaited, so a connection that fails while it
+  // is still being established rejects instead of waiting.
+  ws.onclose = () => abort(chromeGone ?? new Error("DevTools socket closed"));
+  // e.message is routinely the empty string on a transport-level failure, and
+  // an error whose text is blank is no better than the discarded stderr above.
+  ws.onerror = (e) => abort(chromeGone ??
+    new Error(`DevTools socket failed: ${e.error?.message || e.message || "connection lost"}`));
+  ws.onmessage = (e) => {
+    const m = JSON.parse(e.data);
+    if (m.id && pending.has(m.id)) {
+      const { resolve, reject } = pending.get(m.id);
+      pending.delete(m.id);
+      m.error ? reject(new Error(m.error.message)) : resolve(m.result);
+    } else if (m.method) {
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (waiters[i].method === m.method) { waiters[i].resolve(m.params); waiters.splice(i, 1); }
+      }
+    }
+  };
+  await deadline(new Promise((r) => (ws.onopen = r)), OPEN_MS,
+                 "DevTools socket did not open");
+
   await send(ws, "Page.enable");
   await send(ws, "Runtime.enable");
 
@@ -101,7 +225,7 @@ try {
       return { ok: true, pages: r.total };
     })()`,
     awaitPromise: true, returnByValue: true,
-  });
+  }, PAGINATE_MS);
   const out = res.result?.value;
   if (!out?.ok) throw new Error(out?.why || "pagination failed");
 
@@ -110,10 +234,17 @@ try {
     preferCSSPageSize: true,
     marginTop: 0, marginBottom: 0, marginLeft: 0, marginRight: 0,
     displayHeaderFooter: false,
-  });
+  }, PRINT_MS);
   writeFileSync(output, Buffer.from(data, "base64"));
   console.log(`paginated ${out.pages} page(s)`);
+} catch (err) {
+  // Caught rather than left to propagate: an uncaught rejection out of a
+  // top-level await ends the process without running the cleanup below.
+  console.error(`print-page: ${err.message}`);
+  if (chromeErr.trim()) console.error(`chrome said:\n${chromeErr.trim()}`);
+  process.exitCode = 1;
 } finally {
-  ws.close();
-  chrome.kill();
+  try { ws?.close(); } catch { /* already gone */ }
+  await shutdown();
+  rmSync(profile, { recursive: true, force: true, maxRetries: 3 });
 }


### PR DESCRIPTION
`bin/print-page.mjs` spawns Chrome and drives it over DevTools. Only the happy path ever killed it. Every failure mode left a headless browser behind, and two of them left the build wedged with no timeout at all.

Each failure mode below is reproduced against a stub browser, before and after, with `ps` for the survivors. The stubs are three small node scripts: one that starts and never opens a debug port, one that completes the WebSocket handshake and then destroys the socket while staying alive, and one that stays connected and answers nothing. The only change made to the pre-fix script to run these was pointing its hardcoded `CHROME` constant at the stub:

```
28c28
< const CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
---
> const CHROME = process.env.CHROME;
```

---

### 1. Chrome leaks when it never opens a debug port

`endpoint()` and `new WebSocket()` sat above the `try` that owns `chrome.kill()`. The wait expired, the rejection propagated out of a top-level await, and the block that would have killed the child was never entered.

**Before**

```
=== BEFORE / defect 1: browser starts, never opens a debug port ===
--- stray stubs before: 0
Error: Chrome did not expose a DevTools endpoint
    at endpoint (.../pristine.mjs:51:9)
    at async .../pristine.mjs:70:26
--- node exit code: 1   (elapsed 11s)
--- LEAKED: stub still running: 25560
  PID  PPID STAT COMMAND
25560     1 S    fake-chrome-noport
```

`PPID 1` — reparented to init, still running after node was gone.

**After**

```
=== AFTER / defect 1: browser starts, never opens a debug port ===
--- stray stubs before: 0
print-page: Chrome did not expose a DevTools endpoint
chrome said:
fake-chrome-noport: started, will not open a debug port
--- node exit code: 1   (elapsed 24s)
--- CLEAN: no surviving browser process
```

---

### 2. Chrome leaks when the socket drops mid-command

This one is worse than reported. `send()` returned a promise only the reply could settle, and there was no `onclose` or `onerror`. It does not exit 13 — it never exits. The stub drops the socket 1.5s in and stays alive; the script waits forever.

**Before** — killed by hand at 2m25s, both still running:

```
  PID  PPID   ELAPSED COMMAND
25651 25643     02:25 node .../pristine.mjs whitepaper/.build/paper.html
25654 25651     02:25 fake-chrome-dropsocket
```

Under `bin/build-pdf`, which reads the child to completion with no timeout, that hangs the build indefinitely with no output.

**After**

```
=== AFTER / defect 2: socket drops with a command in flight ===
--- stray stubs before: 0
print-page: DevTools socket failed: connection lost
chrome said:
fake-chrome-dropsocket: listening on 52478
fake-chrome-dropsocket: destroying the socket, staying alive
--- node exit code: 1   (elapsed 5s)
--- CLEAN: no surviving browser process
```

---

### 3. Chrome leaks when it stays connected and answers nothing

The same shape as 2, reached without the socket ever closing — so `onclose`/`onerror` alone would not have caught it. There was no deadline on any command.

**Before** — the harness gave up at 90 seconds; nothing in the script ever would have:

```
=== BEFORE: browser alive, answers no command ===
--- node STILL RUNNING after 90s (no command deadline; nothing will ever end this)
27933 27931     01:36 node .../pristine.mjs whitepaper/.build/paper.html
27936 27933     01:35 fake-chrome-silent
--- LEAKED: killing by hand
```

**After**

```
=== AFTER / browser alive, answers no command ===
print-page: Page.enable did not answer (waited 30000ms)
chrome said:
fake-chrome-silent: listening on 52219
fake-chrome-silent: socket open, will not answer
--- node exit code: 1   (elapsed 33s)
--- CLEAN: no surviving browser process
```

---

### 4. Ctrl-C leaked the browser too

Not in the original report, but the same defect by another route and now covered by the same shutdown:

```
=== Ctrl-C mid-run (SIGINT) ===
--- exit: 130
--- headless chrome children left: 0
--- leftover profile dirs: 0
```

---

### 5. Chrome's diagnostics were discarded

`stdio` was `["ignore","ignore","ignore"]`. `bin/build-pdf` got node's own stack trace and nothing from the browser about why it would not start.

**Before**

```
PDF FAILED

        ^
Error: Chrome did not expose a DevTools endpoint
    at endpoint (.../bin/print-page.mjs:51:9)
    at async .../bin/print-page.mjs:70:26

Node.js v24.15.0

--- survivors: 1
29298     1 fake-chrome-noport
```

**After**

```
PDF FAILED

print-page: Chrome did not expose a DevTools endpoint
chrome said:
fake-chrome-noport: started, will not open a debug port

--- survivors: 0
```

---

### 6. The debug port collided, and the endpoint was never checked for ownership

The port was `9333 + pid % 500`. Two runs whose pids are 500 apart collide, and a browser leaked by an earlier failure holds that port — so the script would have driven *that* browser and then killed its own, unrelated, child.

It now passes `--remote-debugging-port=0` and `--user-data-dir=<fresh mkdtemp>`, and reads the port back out of the `DevToolsActivePort` file Chrome writes into that directory. The directory was created milliseconds earlier by this process, so the browser answering there is provably the child we spawned; the OS picks the port, so nothing collides.

Two concurrent runs against real Chrome:

```
=== AFTER: two concurrent runs against real Chrome ===
--- debug ports actually in use by the two children:
    52360  from  .../T/print-page-L1uYY0/DevToolsActivePort
    52361  from  .../T/print-page-up1F5g/DevToolsActivePort
--- run A: exit 0  paginated 27 page(s)
--- run B: exit 0  paginated 27 page(s)
  /tmp/pp-a.pdf                27 pages    1036423 bytes
  /tmp/pp-b.pdf                27 pages    1036423 bytes
--- leftover print-page profile dirs: 0
```

---

### On `--user-data-dir`: the reported reason does not hold, the flag is still right

The report says headless Chrome uses the user's real default profile and so contends whenever Chrome is open. **That does not reproduce on this machine.** Chrome 150's headless mode creates its own scoped temporary profile when `--user-data-dir` is absent. Probed mid-run with the user's own Chrome open (99 processes, pid 1593):

```
25192 25190 /Applications/Google Chrome.app/.../Google Chrome --headless --disable-gpu ...
  .../T/com.google.Chrome.scoped_dir.sZHkC5/Default/ServerCertificate
```

No `DevToolsActivePort` ever appeared in `~/Library/Application Support/Google/Chrome`, the `SingletonLock` stayed pointed at pid 1593, and the pre-fix happy path ran green in 2.5s alongside the running browser. So this was not the trigger for defect 1, and I am not claiming it as a fix.

`--user-data-dir` is in the change on two grounds that do hold: it is what makes the ownership check in item 6 possible, and the profile becomes ours to delete. Chrome removes its own scoped directory only when it exits cleanly, and the new shutdown path is willing to `SIGKILL` — without an explicit directory, every escalated kill would leave a profile behind.

---

### The change

Everything after the spawn is inside one `try`/`finally`. A single rejection stands for the socket closing, erroring, or the child exiting; every wait is raced against it and against a deadline (20s to a usable socket, 30s per command, 180s for pagination, 120s for `printToPDF`). The `finally` closes the socket, sends `SIGTERM`, escalates to `SIGKILL` after three seconds, and removes the profile. `SIGINT`/`SIGTERM` to the script run the same shutdown. The catch is explicit rather than left to propagate, because an uncaught rejection out of a top-level await ends the process without running `finally`.

### Happy path

Unchanged output. `python3 bin/build-pdf`:

```
  paginated 27 page(s)
wrote static/whitepaper.pdf  1,036,423 bytes · 27 pages · 35 controls · 18 contents entries
```

27 pages, byte-identical in size to the committed PDF. `bin/check-js` passes. The rebuilt `static/whitepaper.pdf` is deliberately **not** in this diff — restored with `git checkout` before committing, since it carries the separate text-loss bug being handled elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP3p34Lq3vogMA9fruBsHQ
