### PR TITLE
Read block scalars by indentation, and count the controls once

### DIFF
--- a/bin/build-brand
+++ b/bin/build-brand
@@ -11,7 +11,10 @@ data URIs so headless Chrome renders the real faces with no network.
 
 Requires fonttools and brotli (pip install fonttools brotli) and Chrome.
 """
-import base64, io, pathlib, re, subprocess, sys
+import base64, io, pathlib, subprocess, sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import controls_source
 
 from fontTools.ttLib import TTFont
 from fontTools.varLib.instancer import instantiateVariableFont
@@ -24,15 +27,10 @@ from fontTools.misc.transform import Transform
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 # Same literal, same failure: the count was typed in and read 33 on the day the
-# catalogue became 35. Derived from the source of truth instead.
-def catalogue_size():
-    src = (ROOT / "whitepaper" / "controls.yaml").read_text(encoding="utf-8")
-    ids = re.findall(r"^\s*-\s+id:\s*([A-Z]{3}-\d{2})\s*$", src, re.M)
-    if not ids:
-        raise SystemExit("could not count controls in controls.yaml")
-    return len(set(ids))
-
-N_CONTROLS = catalogue_size()
+# catalogue became 35. Derived from the source of truth instead — through the
+# shared counter, so the campaign graphic cannot say a different number from
+# the card and the page.
+N_CONTROLS = controls_source.catalogue_size()
 FONTS = ROOT / "static" / "fonts"
 BRAND = ROOT / "brand"
 BRAND.mkdir(exist_ok=True)

--- a/bin/build-pdf
+++ b/bin/build-pdf
@@ -26,6 +26,9 @@ and which check-appendix proves still agrees with the paper's own table.
 """
 import pathlib, subprocess, sys, shutil, re, base64, html
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import controls_source
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SRC = ROOT / "whitepaper" / "whitepaper.md"
 OUT = ROOT / "static" / "whitepaper.pdf"
@@ -43,29 +46,14 @@ if not PAGED.exists():
 # this pinned the field order and silently matched zero controls when a new
 # `type:` field was inserted, which is the failure mode to avoid in the script
 # that renders the reference appendix.
+#
+# The reader itself now lives in bin/controls_source.py, because check-appendix
+# proves this appendix against the paper using the same file and the two had
+# drifted into different regexes. Its own copy read a folded scalar as "every
+# indented line that follows", which swallowed the next sibling key, and
+# recognised only `>-` of the six block-scalar indicators.
 def load_controls():
-    t = (ROOT / "whitepaper" / "controls.yaml").read_text(encoding="utf-8")
-    outcomes, controls = [], []
-    for blk in re.split(r"\n(?=  - )", t):
-        if not blk.lstrip().startswith("- "):
-            continue
-        def field(name):
-            # `[ \t-]*` and not `\s+`: the first field of a list entry carries
-            # the dash — `  - id: DIS-01` — and an anchor that only allows
-            # whitespace matches every field except the one that identifies
-            # the record.
-            m = re.search(rf"^[ \t-]*{name}:[ \t]*(?:>-\s*\n((?:[ ]+\S.*\n?)+)|(.+))$",
-                          blk, re.M)
-            if not m:
-                return None
-            v = m.group(1) or m.group(2) or ""
-            return " ".join(v.split()).strip().strip('"')
-        if field("prefix"):
-            outcomes.append({k: field(k) for k in
-                             ("prefix", "name", "requirement", "detail", "evidence")})
-        elif field("id"):
-            controls.append({k: field(k) for k in
-                             ("id", "outcome", "title", "type", "status", "requirement")})
+    outcomes, controls = controls_source.load()
     if not outcomes or not controls:
         sys.exit("could not read controls.yaml — refusing to render an empty appendix")
     return outcomes, controls

--- a/bin/build-pdf
+++ b/bin/build-pdf
@@ -52,10 +52,16 @@ if not PAGED.exists():
 # drifted into different regexes. Its own copy read a folded scalar as "every
 # indented line that follows", which swallowed the next sibling key, and
 # recognised only `>-` of the six block-scalar indicators.
+#
+# The count it reports on the cover is the count the social card and the page
+# report, because control_ids() is the one that answers that question. This
+# script used to accept any block carrying an `id:` in any shape, so it could
+# print a number the card and the og:image did not have.
 def load_controls():
     outcomes, controls = controls_source.load()
     if not outcomes or not controls:
         sys.exit("could not read controls.yaml — refusing to render an empty appendix")
+    controls_source.control_ids()
     return outcomes, controls
 
 OUTCOMES, CONTROLS = load_controls()

--- a/bin/build-social
+++ b/bin/build-social
@@ -11,7 +11,10 @@ showing it advertised something the page does not contain — and at the size a
 feed renders an unfurl, six cards of 8pt labels are noise rather than
 information. An unfurl has one job, which is to be legible at thumbnail size.
 """
-import base64, pathlib, re, subprocess, sys
+import base64, pathlib, subprocess, sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import controls_source
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
@@ -19,14 +22,12 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 # catalogue became 35, on the og:image — the one asset nobody looks at again
 # after they make it, and the one every share of this link renders. Derived
 # from the source of truth so it cannot be wrong twice.
-def catalogue_size():
-    src = (ROOT / "whitepaper" / "controls.yaml").read_text(encoding="utf-8")
-    ids = re.findall(r"^\s*-\s+id:\s*([A-Z]{3}-\d{2})\s*$", src, re.M)
-    if not ids:
-        sys.exit("could not count controls in controls.yaml")
-    return len(set(ids))
-
-N_CONTROLS = catalogue_size()
+#
+# Derived through the same counter Hugo's card filename has to match, because
+# deriving it separately only moved the failure: this counted `[A-Z]{3}-\d{2}`
+# and social-meta.html counts YAML list entries, so a three-digit identifier
+# wrote social-card-34.png while the og:image pointed at social-card-35.png.
+N_CONTROLS = controls_source.catalogue_size()
 
 def face(family, style, weight, fname):
     data = base64.b64encode((ROOT / "static" / "fonts" / fname).read_bytes()).decode()

--- a/bin/check-appendix
+++ b/bin/check-appendix
@@ -31,7 +31,7 @@ def load_yaml_controls():
     out = {}
     for c in controls_source.load()[1]:
         cid = c["id"]
-        if cid and re.fullmatch(r"[A-Z]{3}-\d{2}", cid):
+        if cid and controls_source.ID.fullmatch(cid):
             out[cid] = {"title": c["title"] or "", "type": c["type"] or "",
                         "req": c["requirement"] or ""}
     return out
@@ -47,7 +47,7 @@ def load_paper_table():
         if not line.startswith("|") or ":----" in line:
             continue
         c = [x.strip() for x in line.strip().strip("|").split("|")]
-        if len(c) >= 5 and re.fullmatch(r"[A-Z]{3}-\d{2}", c[1]):
+        if len(c) >= 5 and controls_source.ID.fullmatch(c[1]):
             out[c[1]] = {"title": c[2], "type": c[3], "req": c[4]}
     return out
 

--- a/bin/check-appendix
+++ b/bin/check-appendix
@@ -16,27 +16,24 @@ full stops and quotation marks are normalised; anything else is a difference.
 """
 import pathlib, re, sys, unicodedata
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import controls_source
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
+# Reads through bin/controls_source.py so this gate and build-pdf agree on what
+# a control's requirement text is. They did not: both carried a copy of a folded
+# scalar reader whose continuation group matched any indented line, so a key
+# added after `requirement:` was folded into the requirement, and only `>-` of
+# the six block-scalar indicators was recognised at all.
 def load_yaml_controls():
-    t = (ROOT / "whitepaper" / "controls.yaml").read_text(encoding="utf-8")
     out = {}
-    for blk in re.split(r"\n(?=  - )", t):
-        if not blk.lstrip().startswith("- "):
-            continue
-
-        def field(name):
-            m = re.search(rf"^[ \t-]*{name}:[ \t]*(?:>-\s*\n((?:[ ]+\S.*\n?)+)|(.+))$",
-                          blk, re.M)
-            if not m:
-                return None
-            return " ".join((m.group(1) or m.group(2) or "").split()).strip().strip('"')
-
-        cid = field("id")
+    for c in controls_source.load()[1]:
+        cid = c["id"]
         if cid and re.fullmatch(r"[A-Z]{3}-\d{2}", cid):
-            out[cid] = {"title": field("title") or "", "type": field("type") or "",
-                        "req": field("requirement") or ""}
+            out[cid] = {"title": c["title"] or "", "type": c["type"] or "",
+                        "req": c["requirement"] or ""}
     return out
 
 

--- a/bin/controls_source.py
+++ b/bin/controls_source.py
@@ -1,0 +1,94 @@
+"""One reader for whitepaper/controls.yaml, shared by every script that reads it.
+
+These scripts deliberately do not depend on a YAML library — the repository has
+no Python dependencies and the gates have to run anywhere. That is fine, but it
+meant four scripts each carried their own regex for the same file, and they did
+not agree with each other.
+
+The reader they carried had two faults, both invisible while `requirement:` is
+the last key in every control record:
+
+  * The continuation group `((?:[ ]+\\S.*\\n?)+)` matched ANY indented line,
+    including the next sibling key. Add a `mapping:` key after `requirement:`
+    and Appendix A typesets `…deployment. mapping: nist: CM-8` — the key and its
+    value folded into the requirement sentence. The same shape had already
+    pulled `evidence:` into six `detail:` values on the homepage.
+  * Only `>-` was recognised. `>`, `|`, `|-`, `>+` and `|+` are legal YAML and
+    mean the same thing to every consumer here, because every consumer collapses
+    whitespace. They read back as the literal indicator string, so changing
+    `requirement: >-` to `requirement: |-` gives all 35 controls the requirement
+    `"|-"`, which build-pdf would typeset into the published appendix.
+
+Both are fixed by reading the block scalar the way YAML defines it — by
+indentation — instead of by pattern. A block scalar's content is the run of
+lines indented further than its key; the first line at or below the key's own
+column ends it, whatever it contains. Prose is not mistaken for a key, and a key
+is not mistaken for prose.
+
+Folded (`>`) versus literal (`|`) makes no difference to any caller: all of them
+collapse runs of whitespace to single spaces, so the two fold identically here.
+"""
+import pathlib, re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CATALOGUE = ROOT / "whitepaper" / "controls.yaml"
+
+# `>-`, `>`, `>+`, `|`, `|-`, `|+`, with an optional explicit indentation digit
+# in either order. The digit is accepted and ignored: the indentation is taken
+# from the content, which is what YAML does when the indicator is absent and
+# what every block in this file relies on.
+_BLOCK_HEADER = re.compile(r"[|>][+-]?\d*|[|>]\d*[+-]?")
+
+# `[ \t-]*` and not `\s+`: the first field of a list entry carries the dash —
+# `  - id: DIS-01` — and an anchor that only allows whitespace matches every
+# field except the one that identifies the record. The lead's width is the key's
+# column, which is what the block scalar's extent is measured against.
+def _key_line(name):
+    return re.compile(rf"^(?P<lead>[ \t-]*){re.escape(name)}:[ \t]*(?P<rest>.*?)[ \t]*$")
+
+
+def field(block, name):
+    """The value of `name` in `block`, or None if the key is absent.
+
+    Whitespace is collapsed and surrounding quotes stripped, so callers get the
+    same string whether the value was plain, quoted, folded or literal.
+    """
+    lines = block.split("\n")
+    key = _key_line(name)
+    for i, line in enumerate(lines):
+        m = key.match(line)
+        if not m:
+            continue
+        rest, column = m.group("rest"), len(m.group("lead"))
+        if not _BLOCK_HEADER.fullmatch(rest):
+            return _clean(rest) if rest else None
+        body = []
+        for nxt in lines[i + 1:]:
+            if not nxt.strip():
+                body.append("")
+                continue
+            if len(nxt) - len(nxt.lstrip(" \t")) <= column:
+                break            # a line at or left of the key ends the scalar
+            body.append(nxt)
+        return _clean("\n".join(body))
+    return None
+
+
+def _clean(value):
+    return " ".join(value.split()).strip().strip('"')
+
+
+def load(text=None):
+    """(outcomes, controls) as lists of dicts, in file order."""
+    t = CATALOGUE.read_text(encoding="utf-8") if text is None else text
+    outcomes, controls = [], []
+    for blk in re.split(r"\n(?=  - )", t):
+        if not blk.lstrip().startswith("- "):
+            continue
+        if field(blk, "prefix"):
+            outcomes.append({k: field(blk, k) for k in
+                             ("prefix", "name", "requirement", "detail", "evidence")})
+        elif field(blk, "id"):
+            controls.append({k: field(blk, k) for k in
+                             ("id", "outcome", "title", "type", "status", "requirement")})
+    return outcomes, controls

--- a/bin/controls_source.py
+++ b/bin/controls_source.py
@@ -92,3 +92,54 @@ def load(text=None):
             controls.append({k: field(blk, k) for k in
                              ("id", "outcome", "title", "type", "status", "requirement")})
     return outcomes, controls
+
+
+# ── how many controls are there ──────────────────────────────────────────────
+# Three answers to that question shipped, and they did not have to agree:
+# build-pdf counted any block carrying an `id:` with no format check;
+# build-social and build-brand counted `^\s*-\s+id:\s*([A-Z]{3}-\d{2})\s*$`;
+# social-meta.html counts `len hugo.Data.controls.controls`, which is the real
+# YAML list. The card's filename carries the count on purpose — platforms cache
+# og:image by URL, so the number has to move the URL — which makes a
+# disagreement between the script that writes the file and the template that
+# links it a 404 on every share rather than a wrong caption.
+#
+# `[A-Z]{3}-\d{2}` is not the grammar VERSIONING.md promises. It fixes the
+# number at two digits, and VERSIONING.md's own rules push past that: numbers
+# are never reused, withdrawn ones stay burned, and "gaps are expected and
+# fine", so a family reaches three digits by following the promise rather than
+# by breaking it. A catalogue containing RES-101 counted 34 in build-social and
+# 35 in Hugo, and the og:image pointed at a card that was never written.
+ID = re.compile(r"[A-Z]{3}-\d{2,}")
+
+
+def control_ids(text=None):
+    """Every control identifier, in file order.
+
+    Hugo counts list entries, so this counts list entries too, and refuses
+    rather than returns a number that cannot match. A malformed or duplicated
+    identifier would otherwise be silently dropped here and silently counted
+    there, which is the whole failure being closed.
+    """
+    controls = load(text)[1]
+    bad = [c["id"] for c in controls if not c["id"] or not ID.fullmatch(c["id"])]
+    if bad:
+        raise SystemExit(
+            f"controls.yaml: {len(bad)} identifier(s) are not FAMILY-NN "
+            f"(e.g. {bad[0]!r}). Hugo counts these entries and this script "
+            f"cannot, so the social card and the og:image that links it would "
+            f"disagree. Fix the identifier or widen bin/controls_source.ID.")
+    seen = [c["id"] for c in controls]
+    if len(set(seen)) != len(seen):
+        dupe = next(i for i in seen if seen.count(i) > 1)
+        raise SystemExit(f"controls.yaml: {dupe} appears more than once — "
+                         f"Hugo counts both entries and this script counts one.")
+    return seen
+
+
+def catalogue_size(text=None):
+    """The number social-meta.html puts in the og:image filename."""
+    ids = control_ids(text)
+    if not ids:
+        raise SystemExit("could not count controls in controls.yaml")
+    return len(ids)


### PR DESCRIPTION
Two defects from the launch-day audit: the folded-scalar reader that
`build-pdf` and `check-appendix` share, and the three control counters that can
disagree about how many controls there are.

Every claim below was reproduced against `origin/main` before the fix and
re-run after it. `whitepaper/controls.yaml` is unchanged, `static/whitepaper.pdf`
is not rebuilt, and no content file is touched — the diff is five files under
`bin/`.

---

## 1 · The block-scalar reader

### What was wrong

Both scripts carried their own copy of

```python
rf"^[ \t-]*{name}:[ \t]*(?:>-\s*\n((?:[ ]+\S.*\n?)+)|(.+))$"
```

The continuation group matches any indented line, including the next sibling
key. It is harmless only because `requirement:` is the last key in every control
record today.

### Proof — the sibling key

Added a `mapping:` key after `DIS-01`'s requirement in `controls.yaml`:

```yaml
    requirement: >-
     Maintains a stable identifier and authoritative record for each in-scope
     agent definition or deployment.
    mapping:
      nist: CM-8
```

`build-pdf`'s reader, exercised through the shipped code:

```
before:  DIS-01  requirement = 'Maintains a stable identifier and authoritative
                  record for each in-scope agent definition or deployment.
                  mapping: nist: CM-8'
after:   DIS-01  requirement = 'Maintains a stable identifier and authoritative
                  record for each in-scope agent definition or deployment.'
```

That string is what the published Appendix A typesets. `bin/check-appendix`,
which is supposed to catch exactly this kind of drift, was reading it the same
way and so reported the difference against itself:

```
before:  DIFF   DIS-01 requirement differs                      exit 1
after:   35 rows in the paper · 35 controls · 0 difference(s)    exit 0
```

`bin/check-controls` passed throughout — it has a third, narrower regex without
the fault, so two gates disagreed about what a control requires.

### Proof — the other five indicators

Changed all 35 `requirement: >-` headers to `requirement: |-`, which is legal
YAML and means the same thing here:

```
before:  DIS-01  requirement = '|-'      (all 35)
         check-appendix: 35 difference(s), every one `yaml : |-`   exit 1
after:   DIS-01  requirement = 'Maintains a stable identifier and …'
         check-appendix: 0 difference(s)                           exit 0
```

### Why not the regex the audit proposed

The suggested continuation group was `((?:[ ]+(?!\w[\w-]*:)\S.*\n?)+)`. I ran it
before adopting it. It does stop the sibling key, and it also truncates any
requirement whose first word ends in a colon:

| input | old | proposed |
|---|---|---|
| sibling key follows | `…deployment. mapping: nist: CM-8` | `…deployment.` ✅ |
| `Note: the agent must be registered.` | `Note: the agent must be registered.` | `>-` ❌ |
| `requirement: \|-` | `\|-` | `\|-` ❌ |

Same class of bug, moved: it still decides what a block scalar contains by
looking at the content. The reader now takes the key's column and consumes the
run of lines indented past it, which is how YAML defines the extent. A key is
never read as prose, prose is never read as a key, and all six indicators work
because none of them is special-cased.

Matrix run against `bin/controls_source.py` — `>-`, `>`, `>+`, `|`, `|-`, `|+`,
each bare and each followed by a sibling key, plus prose containing a colon,
plus plain and quoted scalars, plus the sibling key still being readable
afterwards: **16 cases, 0 failures.**

---

## 2 · The control counters

### What was wrong

| where | grammar |
|---|---|
| `bin/build-pdf` | any block with an `id:`, no format check |
| `bin/build-social`, `bin/build-brand` | `^\s*-\s+id:\s*([A-Z]{3}-\d{2})\s*$` |
| `layouts/partials/social-meta.html` | `len hugo.Data.controls.controls` |

The card's filename carries the count deliberately — platforms cache `og:image`
by URL, so the number has to move the URL. That makes a disagreement between the
script that writes the file and the template that links it a 404 on every share.

### Proof — a three-digit identifier

`RES-05` → `RES-101` in `controls.yaml`, `hugo --gc --minify`, then every
counter asked the same question through the shipped code:

```
before:  build-pdf     cover and appendix          35
         build-social  writes social-card-34.png    34
         build-brand   campaign graphic            34
         hugo          og:image social-card-35.png  35
         DISAGREE — the og:image 404s

after:   all four: 35 · social-card-35.png · og:image social-card-35.png
         AGREE
```

`[A-Z]{3}-\d{2}` is not the grammar `VERSIONING.md` promises. It fixes the
number at two digits, and the document's own rules walk past that: identifiers
are never reused, withdrawn ones stay burned, and "gaps are expected and fine",
so a family reaches three digits by keeping the promise rather than by breaking
it.

One correction to the audit's framing, since it matters for review:
`VERSIONING.md` does **not** permit renaming `RES-05` to `RES-101` — "Renumber a
control ❌ Never" is explicit. What it permits is *adding* `RES-101`. The rename
is the sharper reproduction of the counting bug and that is why it is used here;
the legal route to the same catalogue reaches it by addition.

### Proof — a trailing comment, with every gate green

The 404 does not need a novel identifier. `- id: RES-05  # provisional` is legal
YAML, Hugo counts the entry, `\s*$` cannot reach past the comment, and
`check-controls` reads the id with `(\S+)` and is satisfied:

```
before:  check-controls  0 error(s), 3 warning(s)      exit 0
         build-social writes social-card-34.png
         hugo          og:image social-card-35.png     DISAGREE

after:   controls.yaml: 1 identifier(s) are not FAMILY-NN (e.g. 'RES-05 # provisional').
         Hugo counts these entries and this script cannot, so the social card and
         the og:image that links it would disagree.                exit 1
```

The build now refuses and says which identifier, instead of writing a card at a
filename nothing links to.

### What changed

There is one counter, in `bin/controls_source.py`. It counts list entries rather
than regex matches, so it answers Hugo's question by construction; where it
cannot — an identifier outside the grammar, or one appearing twice — it stops
and names it. The grammar is `FAMILY-NN` with the number free to grow, defined
once, so the next widening is one edit rather than three.

`check-controls` keeps its own `FAMILY-NN` rule. That one is the ADR-0001
identifier policy gate rather than a counter, and relaxing it is a governance
call, not a bug fix. A three-digit identifier is therefore still rejected today
— loudly, by the gate whose job that is, rather than silently by the script that
writes the social card. **If the project wants `RES-101` to be landable, that is
the one line to change, and it belongs in its own PR.**

---

## Gates

All run on the final tree, `whitepaper/controls.yaml` restored:

| gate | result |
|---|---|
| `hugo --gc --minify` | 6 pages, ok |
| `bin/check-controls` | 0 errors, 3 pre-existing warnings — exit 0 |
| `bin/check-copy --strict` | 7 sources, 194 sentences, 0 findings — exit 0 |
| `bin/check-js` | 2 scripts, 0 failed — exit 0 |
| `bin/check-figure` | 880×390, 20 text runs, 0 errors — exit 0 |
| `bin/check-appendix` | 35 rows · 35 controls, 0 differences — exit 0 |
| `bin/render-controls` + drift | `CONTROLS.md` byte-identical |
| figure rebuild + drift | SVGs byte-identical |

`check-figure` needs `whitepaper/figures/build-figure-1.py` run first for the box
manifest, as CI does; it fails on a clean checkout without it, before and after
this change alike.

`bin/check-bindings` exists only on `restore-outcome-detail` and could not be
run here. It reads `controls.yaml` for field *names*, not values, so it carries
neither fault and does not conflict with this change.

## Not in scope

`bin/render-controls` carries a fourth reader — `requirement: >-\n((?:     .*\n?)+)`.
The exact five-space continuation means it does not swallow sibling keys, but it
does share the indicator limitation: `|-` would empty every requirement in
`CONTROLS.md`. Left alone here because it is a different regex in a script the
brief did not name, and folding it in would move generated output into a fix PR.
Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP3p34Lq3vogMA9fruBsHQ
