### PR TITLE
Stop promising anything is immutable

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,16 +20,7 @@
   ],
   "headers": [
     {
-      "source": "/fonts/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    },
-    {
-      "source": "/(css|js)/(.*)",
+      "source": "/(fonts|css|js)/(.*)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
`immutable` says the bytes at a URL will **never change** — not "cache for a year", but *never ask again*. Browsers honour it, and so do CDNs, corporate proxies, and the link scrapers at LinkedIn and Slack. None of which we can reach into and correct.

The precondition for saying that is exactly one thing: **the filename is derived from the content.** A hash.

I put it on `/fonts/` this morning and justified it by claiming a woff2 changes filename when the type changes. **It doesn't.** `figtree-normal-400-latin.woff2` names a family, a style, a weight and a subset — re-subset it for more glyphs, or take a newer Figtree upstream, and the same filename carries different bytes. The precondition never held.

```
-  /fonts/(.*)          public, max-age=31536000, immutable
-  /(css|js)/(.*)       public, max-age=0, must-revalidate
+  /(fonts|css|js)/(.*) public, max-age=0, must-revalidate
```

With `immutable` gone the two rules are identical, so the split has no purpose and collapses back into one.

**What it buys:** one conditional request per asset, answered with a bodyless 304.
**What it costs:** the ability to correct anything for a year, during a comment period that runs to 30 September, on a project whose pitch is being versioned in the open.

If the performance is wanted later, the answer is content-hashed filenames — then `immutable` is simply true rather than hopeful.

**Related: #14 adds `/social-card-(.*)` with `immutable`, and should drop it for the same reason.** That filename tracks the control count while the card also bakes in `v1.0-draft` — so v1.0 with the count still 35 puts new bytes at the same pinned URL. Being handled on that branch.