### PR TITLE
Make a control's address citable, so arrival can measure citation

### DIFF
--- a/.github/workflows/controls.yml
+++ b/.github/workflows/controls.yml
@@ -47,6 +47,17 @@ jobs:
           python3 whitepaper/figures/build-figure-1.py
           git diff --exit-code whitepaper/figures/*.svg \
             || { echo "::error::figure-1.svg is stale — regenerate it from controls.yaml"; exit 1; }
+      # The step above gates whitepaper/figures/*.svg. The site does not render
+      # those: it renders layouts/partials/figure-1*.svg, which bin/sync-figure-partial
+      # generates from them, and which nothing gated. Rebuild the figure, forget the
+      # sync, commit — every check above passes and the page keeps serving the
+      # previous figure. The same "green run over an unchecked derived artifact"
+      # shape the comments above keep describing, on the copy a reader actually sees.
+      - name: Re-sync the rendered figure partials and fail on drift
+        run: |
+          python3 bin/sync-figure-partial
+          git diff --exit-code layouts/partials/figure-1.svg layouts/partials/figure-1-narrow.svg \
+            || { echo "::error::layouts/partials/figure-1*.svg are stale — run bin/sync-figure-partial"; exit 1; }
       # static/whitepaper.pdf is the handout. It is committed, so it can go stale
       # the same way CONTROLS.md and figure-1.svg can, and it is the one artifact
       # where `git diff` cannot show it: a megabyte of binary reads as "modified"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -28,6 +28,11 @@ agentbaseline.org/DIS-01
 The identifier stays byte-stable. The namespace is metadata and may change; a citation written
 against the bare identifier survives that change.
 
+The second form resolves: `agentbaseline.org/DIS-01` redirects to the control on the controls
+page. That is a redirect rather than a page of its own, so **the address is not the
+identifier** — it is one way to look one up, it moves if this work moves, and the bare
+identifier is the thing you cite. `/controls#DIS-01` is the same destination written out.
+
 ## The stability promise
 
 **Identifiers are superseded, never renumbered, and never reused.**

--- a/bin/check-controls
+++ b/bin/check-controls
@@ -17,6 +17,55 @@ errors, warnings = [], []
 def err(m): errors.append(m)
 def warn(m): warnings.append(m)
 
+# ── 0 · the built output must come from this configuration ───────────────────
+# Every check below that reads public/ is only as good as the build that made
+# it. A `hugo server` left running rewrites public/ continuously with a
+# localhost baseURL, so a check can validate a build nobody deployed and pass.
+# That cost three false alarms in one evening: a reorder that had worked was
+# reported as broken, twice.
+#
+# This sits at the top rather than at the bottom, where it used to. Below §7 it
+# ran *after* the check it exists to protect had already read the suspect build,
+# and its sys.exit then discarded every finding §1-§6 had collected — so a real
+# controls.yaml defect plus a stale public/ showed you only the stale-build
+# complaint. bin/check-copy has the same code in the right place; this file did
+# not. Nothing is collected yet here, so refusing outright costs no findings.
+_cfg = (ROOT / "hugo.toml").read_text(encoding="utf-8")
+_base = re.search(r'^baseURL\s*=\s*"([^"]+)"', _cfg, re.M)
+
+# The shape of baseURL, not its value. It decides the canonical tag, and the
+# canonical tag is what /controls puts on a reader's clipboard when they click an
+# identifier — so a build configured for a preview host ships citations that die
+# with the deployment, silently. Pinning the literal domain would fight
+# VERSIONING.md and ADR-0001, which promise identifiers survive a transfer to a
+# community body precisely because they carry no project name; a rename to any
+# real domain must stay green. Shape catches every accidental preview and every
+# localhost build without naming the project.
+if not _base:
+    sys.exit("hugo.toml declares no baseURL — every canonical on the site, and "
+             "every address the controls page copies, is derived from it.")
+_bad_host = re.match(r'^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])'
+                     r'|^https?://[^/]*\.vercel\.(app|sh)/?$', _base.group(1))
+if not _base.group(1).startswith("https://") or _bad_host:
+    sys.exit(f"hugo.toml baseURL is not a published https origin: {_base.group(1)}\n"
+             f"The controls page copies this origin to the clipboard as the "
+             f"citable address of a control, so a preview or localhost value "
+             f"ships citations that resolve for nobody.\n"
+             f"Any real https domain is fine — this pins the shape, not the name, "
+             f"so a transfer to a community body stays green.")
+
+_built = ROOT / "public" / "index.html"
+if _built.exists():
+    _got = re.search(r'canonical["\']?\s+href=["\']?([^"\'>\s]+)',
+                     _built.read_text(encoding="utf-8"))
+    if _got and not _got.group(1).startswith(_base.group(1).rstrip("/")):
+        sys.exit(f"public/ was built with a different baseURL than hugo.toml sets.\n"
+                 f"  hugo.toml : {_base.group(1).rstrip('/')}\n"
+                 f"  public/   : {_got.group(1)}\n"
+                 f"Usually a `hugo server` is still running and rewriting public/.\n"
+                 f"  pkill -f 'hugo server' && hugo --gc --minify\n"
+                 f"Refusing to check a build that is not the one you would deploy.")
+
 src = CAT.read_text(encoding="utf-8")
 
 # ── parse ─────────────────────────────────────────────────────────────────────
@@ -113,8 +162,20 @@ if PAPER.exists():
 
 # ── 7. built output must agree with the source of truth ──────────────────────
 # Asserts the rendered ranges rather than grepping for the shape of a past bug.
+#
+# `public/` is gitignored and CI runs this file as its first step, before any
+# hugo invocation — so for the whole life of this check the directory was absent,
+# `if built.exists()` was false, and it reported a pass having asserted nothing.
+# Indistinguishable, in output and exit code, from a run that checked all six
+# families. bin/check-js states the rule this broke: a gate that reports success
+# when it did not run is worse than no gate, because it is the one you stop
+# checking. Say so instead, and let the caller decide whether that is fatal.
 built = ROOT / "public" / "index.html"
-if built.exists():
+if not built.exists():
+    warn("§7 did not run: public/ is absent, so the rendered identifier ranges "
+         "were not checked. Run `hugo --gc --minify` first, or run this after "
+         "the build step rather than before it.")
+else:
     html = built.read_text(encoding="utf-8")
     for fam, n in sorted(hi_by_fam.items()):
         for m in re.finditer(rf"{fam}-(\d{{2}})…(\d{{2}})", html):
@@ -134,34 +195,6 @@ for _m in re.finditer(r'  - id: (\w+-\d+)\n(?:.*\n)*?    requirement: >-\n((?:  
     if _lines and len(_lines[-1].split()) == 1 and _lines[-1].rstrip(".").lower() in _NAMES:
         err(f"{_m.group(1)}: requirement ends in the bare word "
             f"'{_lines[-1]}' — a heading pasted in from the source document")
-
-# ── 0 · the built output must come from this configuration ───────────────────
-# Every check below that reads public/ is only as good as the build that made
-# it. A `hugo server` left running rewrites public/ continuously with a
-# localhost baseURL, so a check can validate a build nobody deployed and pass.
-# That cost three false alarms in one evening: a reorder that had worked was
-# reported as broken, twice.
-def _built_matches_config():
-    cfg = (ROOT / "hugo.toml").read_text(encoding="utf-8")
-    m = re.search(r'^baseURL\s*=\s*"([^"]+)"', cfg, re.M)
-    built = ROOT / "public" / "index.html"
-    if not m or not built.exists():
-        return None
-    want = m.group(1).rstrip("/")
-    h = built.read_text(encoding="utf-8")
-    got = re.search(r'canonical["\']?\s+href=["\']?([^"\'>\s]+)', h)
-    if got and not got.group(1).startswith(want):
-        return (want, got.group(1))
-    return None
-
-_drift = _built_matches_config()
-if _drift:
-    sys.exit(f"public/ was built with a different baseURL than hugo.toml sets.\n"
-             f"  hugo.toml : {_drift[0]}\n"
-             f"  public/   : {_drift[1]}\n"
-             f"Usually a `hugo server` is still running and rewriting public/.\n"
-             f"  pkill -f 'hugo server' && hugo --gc --minify\n"
-             f"Refusing to check a build that is not the one you would deploy.")
 
 # ── report ────────────────────────────────────────────────────────────────────
 fam = collections.Counter(c["id"].split("-")[0] for c in controls)

--- a/layouts/controls.html
+++ b/layouts/controls.html
@@ -58,6 +58,8 @@
   a svg.ph { color:inherit; }
   a:visited { color:var(--visited); }
   a:focus-visible { outline:2px solid var(--link); outline-offset:2px; }
+  .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px;
+    overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
   /* Ninety-six focusable elements sit ahead of the catalogue here — the whole
      identifier rail is in front of it. A keyboard reader clears them in one
      tab. Off-canvas until focused; fixed, so it never lengthens the page. */
@@ -260,27 +262,54 @@
     display:grid; grid-template-columns:82px 1fr; gap:2px 14px; scroll-margin-top:72px; }
   ol.controls li:first-child { border-top:1px solid var(--line); }
   ol.controls li:target { background:var(--wash); box-shadow:-10px 0 0 var(--wash),10px 0 0 var(--wash); }
-  ol.controls .cid { grid-row:1/3; font-family:var(--mono); font-size:12px; font-weight:700;
+  /* The utility bar is sticky and wraps, so its height is a function of width:
+     measured 50.25px at 1100px and up, 89-92px from 540-900px, 132.25px at
+     520px and below. A flat 72px put the top of the targeted row underneath it
+     at every width below 1100px, and once a click had a confirmation to show,
+     that landed under the header too — on a phone the feature read as doing
+     nothing at all. Keep these values above the heights above.
+
+     These sit after the two rules they override, not before: a media query adds
+     no specificity, so `ol.controls li` inside one ties with `ol.controls li`
+     outside it and source order is the only thing that decides. */
+  @media (max-width:1099px) { h2[id], ol.controls li { scroll-margin-top:104px; } }
+  @media (max-width:539px)  { h2[id], ol.controls li { scroll-margin-top:148px; } }
+  /* The cell spans both rows and is the positioning context, so the anchor can
+     stay stretched. An earlier version shrank the anchor to its text to give
+     the badge something to hang off, which cost 69% of the click target — the
+     text did not move but the target collapsed from 82x77 to 82x24, and a click
+     in the gutter that used to jump to the control did nothing at all. */
+  ol.controls .cidcell { grid-row:1/3; position:relative; display:flex;
+    flex-direction:column; align-items:flex-start; }
+  ol.controls .cid { flex:1 1 auto; min-height:24px; box-sizing:border-box;
+    font-family:var(--mono); font-size:12px; font-weight:700;
     color:var(--accent); text-decoration:none; padding-top:3px;
     font-variant-numeric:tabular-nums;
-    /* align-self so the box hugs its text rather than stretching across both
-       rows — the text does not move, but the badge below can be positioned
-       against the identifier instead of against the bottom of the row. */
-    align-self:start; position:relative; }
+    display:flex; align-items:baseline; gap:5px; }
   ol.controls .cid:hover { color:var(--link-hover); }
+  /* The glyph advertises the second effect. Without it the identifier looks
+     exactly like the plain self-link it used to be, and clicking it silently
+     replaces whatever the reader had on their clipboard. aria-hidden, so the
+     accessible name stays the bare identifier. */
+  ol.controls .cid svg.ph { width:10px; height:10px; flex:none;
+    opacity:.45; transition:opacity .12s ease-out; }
+  ol.controls .cid:hover svg.ph, ol.controls .cid:focus-visible svg.ph { opacity:1; }
   /* Confirmation that the address is on the clipboard. Absolute and
-     pointer-events:none so a badge appearing cannot reflow the roster or
-     swallow the second click. The class is only ever added by script, after the
-     clipboard write resolves — nothing here claims a copy that did not happen. */
-  ol.controls .cid::after { content:"copied"; position:absolute; left:0;
-    top:calc(100% + 3px); font-family:var(--labelfont); font-size:9.5px;
+     pointer-events:none so it cannot reflow the roster or swallow a second
+     click. Rendered empty and only filled by script after the clipboard write
+     resolves, so nothing claims a copy that did not happen. */
+  /* 27px = the identifier's own line box (12px x 1.75 line-height, + 3px
+     padding-top) plus a 3px gap, so the chip sits under the text rather than
+     over it now that the anchor fills the whole two-row cell. */
+  ol.controls .cidflag { position:absolute; left:0; top:27px;
+    font-family:var(--labelfont); font-size:9.5px;
     font-weight:500; letter-spacing:.1em; text-transform:uppercase;
     color:var(--paper); background:var(--accent); padding:1px 5px;
     border-radius:2px; white-space:nowrap; pointer-events:none;
     opacity:0; transition:opacity .12s ease-out; }
-  ol.controls .cid.copied::after { opacity:1; }
+  ol.controls .cidcell.copied .cidflag { opacity:1; }
   @media (prefers-reduced-motion:reduce) {
-    ol.controls .cid::after { transition:none; }
+    ol.controls .cidflag, ol.controls .cid svg.ph { transition:none; }
   }
   ol.controls .ctitle { font-family:var(--head); font-size:15.5px;
     font-weight:600; letter-spacing:-0.005em; }
@@ -289,9 +318,13 @@
   .cite { font-family:var(--mono); font-size:13px; background:var(--wash);
     border:1px solid var(--line); border-radius:3px; padding:12px 14px;
     overflow-x:auto; margin:0 0 16px; }
-  /* One exhibit per line without pre-wrapping the block, so a long address
-     still scrolls rather than forcing the page wide. */
-  .cite span { display:block; }
+  /* One exhibit per line. nowrap is what makes the existing overflow-x:auto do
+     any work: without it the address wrapped at the hyphen in the identifier
+     and rendered as "agentbaseline.org/controls#DIS-" / "01" at 340px and
+     below, because a hyphen is a soft-wrap opportunity and overflow-x only
+     engages when there is no break opportunity at all. A block whose whole job
+     is to show one exact string a reader will paste must not break it. */
+  .cite span { display:block; white-space:nowrap; }
   .cite span + span { margin-top:2px; color:var(--soft); }
   p.note { color:var(--soft); font-size:16px; max-width:66ch; margin:0 0 14px; }
 
@@ -395,8 +428,22 @@
   <p class="outcome-req">{{ .requirement }}</p>
   <ol class="controls">
     {{- range $ids }}
+    {{/* The confirmation is a sibling of the anchor, never inside it. As a
+         ::after on the link it put the word "copied" into the accessible name of
+         all 35 identifiers from page load — opacity:0 hides pixels, not the
+         accessibility tree — so every control announced a copy that had not
+         happened, in Chromium, Firefox and WebKit alike. aria-hidden cannot
+         apply to a pseudo element, which is why this is a real span.
+
+         Class names are written bare here on purpose. check-bindings scans this
+         block for dot-prefixed tokens and cannot tell a catalogue field from
+         prose, so naming a CSS class the way CSS does makes it report a missing
+         field that was only ever a comment. */}}
     <li id="{{ .id }}">
-      <a class="cid" href="#{{ .id }}">{{ .id }}</a>
+      <span class="cidcell">
+        <a class="cid" href="#{{ .id }}">{{ .id }}{{ partial "icons/copy.svg" $ }}</a>
+        <span class="cidflag" aria-hidden="true">copied</span>
+      </span>
       <span class="ctitle">{{ .title }}</span>
       <span class="creq">{{ .requirement }}</span>
     </li>
@@ -412,19 +459,36 @@
        and by someone in a hurry. The bare form stays first and stays the
        canonical one: the portability argument below is load-bearing. */}}
   <div class="cite"><span>DIS-01 (Agent Baseline v{{ .Site.Params.version }})</span>
-    <span>{{ strings.TrimPrefix "https://" (strings.TrimSuffix "/" .Permalink) }}#DIS-01</span></div>
+    <span>{{ strings.TrimSuffix "/" .Permalink }}#DIS-01</span></div>
   <p class="note">The first is the form for an audit finding, a policy document or an RFP
   response — the identifier, and enough to resolve it. Identifiers are bare and
   permanent: superseded, never renumbered, never reused, and carrying no project name
   so that a rename or a transfer to a community body never breaks a reference you have
   already published.</p>
+  {{/* The scheme is shown rather than trimmed, because the clipboard receives
+       the absolute form and an exhibit that differs from what the button
+       produces is a defect on a page about citation precision. It also autolinks
+       in trackers, which is the stated use.
+
+       "Every identifier above" was the previous wording and it was false: the
+       rail at the top of this page renders all 35 identifiers, is physically
+       above this block, and does not copy. Name the roster instead. */}}
   <p class="note">The second is the same control as an address, for a ticket, a review
-  comment or anywhere else a link can travel. Every identifier above is one — click it
-  and the full address is on your clipboard.</p>
+  comment or anywhere else a link can travel. Each identifier in the list of controls
+  copies its address when you click it. Note that the address is the one thing here
+  that can perish: if this work moves, the address moves with it and the bare
+  identifier does not.</p>
   <p class="note">To cite the document itself: Agent Baseline, v{{ .Site.Params.version }},
   agentbaseline.org, {{ .Site.Params.published }}.</p>
 
 </main>
+
+{{/* Rendered empty, and filled by theme.js when an address reaches the
+     clipboard. In the template rather than created on first copy: a region
+     created and mutated ~60ms apart is the case assistive technologies are
+     least reliable about, and it is the first copy of a session that pays for
+     it. Inert without the script. */}}
+<div id="copystatus" role="status" aria-live="polite" class="sr-only"></div>
 
 <footer>
   <span>Prose and figures CC BY 4.0 · schemas Apache-2.0 ·

--- a/layouts/controls.html
+++ b/layouts/controls.html
@@ -262,8 +262,26 @@
   ol.controls li:target { background:var(--wash); box-shadow:-10px 0 0 var(--wash),10px 0 0 var(--wash); }
   ol.controls .cid { grid-row:1/3; font-family:var(--mono); font-size:12px; font-weight:700;
     color:var(--accent); text-decoration:none; padding-top:3px;
-    font-variant-numeric:tabular-nums; }
+    font-variant-numeric:tabular-nums;
+    /* align-self so the box hugs its text rather than stretching across both
+       rows — the text does not move, but the badge below can be positioned
+       against the identifier instead of against the bottom of the row. */
+    align-self:start; position:relative; }
   ol.controls .cid:hover { color:var(--link-hover); }
+  /* Confirmation that the address is on the clipboard. Absolute and
+     pointer-events:none so a badge appearing cannot reflow the roster or
+     swallow the second click. The class is only ever added by script, after the
+     clipboard write resolves — nothing here claims a copy that did not happen. */
+  ol.controls .cid::after { content:"copied"; position:absolute; left:0;
+    top:calc(100% + 3px); font-family:var(--labelfont); font-size:9.5px;
+    font-weight:500; letter-spacing:.1em; text-transform:uppercase;
+    color:var(--paper); background:var(--accent); padding:1px 5px;
+    border-radius:2px; white-space:nowrap; pointer-events:none;
+    opacity:0; transition:opacity .12s ease-out; }
+  ol.controls .cid.copied::after { opacity:1; }
+  @media (prefers-reduced-motion:reduce) {
+    ol.controls .cid::after { transition:none; }
+  }
   ol.controls .ctitle { font-family:var(--head); font-size:15.5px;
     font-weight:600; letter-spacing:-0.005em; }
   ol.controls .creq { font-size:15px; color:var(--soft); line-height:1.6; }
@@ -271,6 +289,10 @@
   .cite { font-family:var(--mono); font-size:13px; background:var(--wash);
     border:1px solid var(--line); border-radius:3px; padding:12px 14px;
     overflow-x:auto; margin:0 0 16px; }
+  /* One exhibit per line without pre-wrapping the block, so a long address
+     still scrolls rather than forcing the page wide. */
+  .cite span { display:block; }
+  .cite span + span { margin-top:2px; color:var(--soft); }
   p.note { color:var(--soft); font-size:16px; max-width:66ch; margin:0 0 14px; }
 
   /* A sibling of <main>, not a child of it: contentinfo is a landmark of the
@@ -383,12 +405,22 @@
   {{- end }}
 
   <h2>Referencing a control</h2>
-  <div class="cite">DIS-01 (Agent Baseline v{{ .Site.Params.version }})</div>
-  <p class="note">That is the form for an audit finding, a policy document or an RFP
+  {{/* Two forms, because the page's own test — "the identifier, and enough to
+       resolve it" — is not met by the bare form alone. A reader who meets
+       DIS-01 in a vendor questionnaire has nothing to follow and has to go
+       searching; the address is what makes the citation resolvable by a machine
+       and by someone in a hurry. The bare form stays first and stays the
+       canonical one: the portability argument below is load-bearing. */}}
+  <div class="cite"><span>DIS-01 (Agent Baseline v{{ .Site.Params.version }})</span>
+    <span>{{ strings.TrimPrefix "https://" (strings.TrimSuffix "/" .Permalink) }}#DIS-01</span></div>
+  <p class="note">The first is the form for an audit finding, a policy document or an RFP
   response — the identifier, and enough to resolve it. Identifiers are bare and
   permanent: superseded, never renumbered, never reused, and carrying no project name
   so that a rename or a transfer to a community body never breaks a reference you have
   already published.</p>
+  <p class="note">The second is the same control as an address, for a ticket, a review
+  comment or anywhere else a link can travel. Every identifier above is one — click it
+  and the full address is on your clipboard.</p>
   <p class="note">To cite the document itself: Agent Baseline, v{{ .Site.Params.version }},
   agentbaseline.org, {{ .Site.Params.published }}.</p>
 

--- a/layouts/partials/icons/copy.svg
+++ b/layouts/partials/icons/copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="ph" aria-hidden="true" focusable="false" viewBox="0 0 256 256" fill="none" stroke="currentColor" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"><path d="M92,92V44a16,16,0,0,1,16-16H212a16,16,0,0,1,16,16V148a16,16,0,0,1-16,16H164"/><rect x="28" y="92" width="136" height="136" rx="16"/></svg>

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -149,6 +149,78 @@
     if (t && typeof va === 'function') va('event', { name: t[0], data: t[1] });
   });
 
+  /* Copying the permalink, not merely navigating to it.
+
+     The identifier beside each control is an anchor to itself, so clicking it
+     moves the page a few pixels and leaves the reader to go to the address bar
+     for anything they can paste. RFC, WHATWG and W3C pages put the absolute
+     address on the clipboard instead, and that is the step between reading a
+     control and citing one — which is the behaviour `arrival` above is trying
+     to measure and currently cannot.
+
+     Layered on the anchor rather than replacing it: no preventDefault, so
+     ⌘-click, middle-click (which fires auxclick, never seen here) and keyboard
+     activation all navigate exactly as they did before, and the link still
+     works with this file blocked. Modified clicks are left alone entirely —
+     someone opening a control in a new tab did not ask for a clipboard write.
+
+     The address is built from the page's own canonical tag, not location.href,
+     so a preview deployment copies the citable agentbaseline.org form instead
+     of its own hostname — a copied preview URL is a broken citation, and it
+     would be broken silently. */
+  function citation(id) {
+    var c = document.querySelector('link[rel="canonical"]');
+    var base = ((c && c.href) || location.href).replace(/[?#].*$/, '');
+    return base.replace(/\/+$/, '') + '#' + id;
+  }
+
+  /* The badge is visual only, so a screen reader is told separately. Built here
+     rather than in the template because it is meaningless without this file. */
+  var live;
+  function announce(msg) {
+    if (!live) {
+      live = document.createElement('div');
+      live.setAttribute('aria-live', 'polite');
+      live.setAttribute('role', 'status');
+      live.style.cssText = 'position:absolute;width:1px;height:1px;margin:-1px;'
+        + 'padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
+      document.body.appendChild(live);
+    }
+    live.textContent = '';
+    /* Same string twice in a row is not re-announced; clearing first, on a
+       separate task, is what makes a second copy audible. */
+    setTimeout(function () { live.textContent = msg; }, 60);
+  }
+
+  var flashed, flashTimer;
+  function flash(a) {
+    clearTimeout(flashTimer);
+    if (flashed) flashed.classList.remove('copied');
+    flashed = a;
+    a.classList.add('copied');
+    flashTimer = setTimeout(function () {
+      a.classList.remove('copied');
+      flashed = null;
+    }, 1600);
+  }
+
+  document.addEventListener('click', function (e) {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    var a = e.target.closest && e.target.closest('a.cid[href^="#"]');
+    if (!a) return;
+    var id = a.getAttribute('href').slice(1);
+    if (!/^(?:DIS|CON|AUT|VAL|OBS|RES)-\d{2}$/.test(id)) return;
+    if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+    navigator.clipboard.writeText(citation(id)).then(function () {
+      flash(a);
+      announce(id + ' address copied');
+    }, function () {
+      /* Denied, or no permission in this context. The navigation already
+         happened, so the reader is no worse off than before — and nothing
+         claims a copy that did not occur. */
+    });
+  });
+
   /* Delegated, so the listener can bind before the body exists. Keyboard
      activation of the button arrives here as a click event. */
   /* Event strip: dismissed per event id, so a new event shows again to someone

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -17,7 +17,13 @@
        hash, and this event does not fire even though the citation worked
        perfectly. `arrival` counts linked citations only. A low number is not
        evidence of low reach, in the same way `rsvp` reading zero would not have
-       been evidence nobody wanted to come. Read it as a floor. */
+       been evidence nobody wanted to come. Read it as a floor.
+
+       It is also a floor that can be crossed by accident: this matches the hash
+       without checking that an element with that id exists, so a link to a
+       control that is not on the page still counts as an arrival. `copy` below
+       is the leading indicator worth watching instead — it fires only when an
+       address actually reached someone's clipboard. */
     var hash = (location.hash || '').slice(1);
     if (/^(?:DIS|CON|AUT|VAL|OBS|RES)-\d{2}$/.test(hash) && typeof va === 'function') {
       va('event', { name: 'arrival', data: { at: hash } });
@@ -155,52 +161,89 @@
      moves the page a few pixels and leaves the reader to go to the address bar
      for anything they can paste. RFC, WHATWG and W3C pages put the absolute
      address on the clipboard instead, and that is the step between reading a
-     control and citing one — which is the behaviour `arrival` above is trying
-     to measure and currently cannot.
+     control and citing one. A copy emits its own event below, because otherwise
+     this would be the same shape of blind spot as `arrival` at the top of the
+     file: the behaviour named as the motivation, going unmeasured.
 
      Layered on the anchor rather than replacing it: no preventDefault, so
      ⌘-click, middle-click (which fires auxclick, never seen here) and keyboard
-     activation all navigate exactly as they did before, and the link still
-     works with this file blocked. Modified clicks are left alone entirely —
-     someone opening a control in a new tab did not ask for a clipboard write.
+     activation all still navigate, and the link works with this file blocked.
+     Keyboard activation also copies — it arrives here as a click. Modified
+     clicks are skipped entirely: someone opening a control in a new tab did not
+     ask for a clipboard write.
 
-     The address is built from the page's own canonical tag, not location.href,
-     so a preview deployment copies the citable agentbaseline.org form instead
-     of its own hostname — a copied preview URL is a broken citation, and it
-     would be broken silently. */
+     The address is the one the document declares as its own canonical, rather
+     than the origin it happens to be served from. That is the published address
+     exactly as long as the build's `baseURL` is the published one, which
+     bin/check-controls asserts the shape of — it is not a guarantee this
+     function can make on its own, and an earlier version of this comment
+     claimed it was.
+
+     Assembled through URL rather than by trimming the string: stripping a
+     trailing slash off a root canonical also strips the path, which turned
+     `https://agentbaseline.org/` into a citation pointing at the homepage with
+     a fragment that does not exist there. Unreachable while .cid renders only
+     on this page, which is exactly why it would have gone unnoticed. */
   function citation(id) {
     var c = document.querySelector('link[rel="canonical"]');
-    var base = ((c && c.href) || location.href).replace(/[?#].*$/, '');
-    return base.replace(/\/+$/, '') + '#' + id;
+    var u;
+    try { u = new URL((c && c.getAttribute('href')) || '', location.href); }
+    catch (e) { u = new URL(location.href); }
+    u.search = '';
+    u.hash = id;
+    return u.href;
   }
 
-  /* The badge is visual only, so a screen reader is told separately. Built here
-     rather than in the template because it is meaningless without this file. */
-  var live;
+  /* The confirmation chip is aria-hidden, so a screen reader is told here
+     instead. The region is rendered empty in the template rather than built on
+     first use: created and populated ~60ms apart, the first announcement of a
+     session is the one an assistive technology is least likely to pick up, and
+     an empty div costs nothing to ship. */
+  function liveRegion() { return document.getElementById('copystatus'); }
+  var announceTimer;
   function announce(msg) {
-    if (!live) {
-      live = document.createElement('div');
-      live.setAttribute('aria-live', 'polite');
-      live.setAttribute('role', 'status');
-      live.style.cssText = 'position:absolute;width:1px;height:1px;margin:-1px;'
-        + 'padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
-      document.body.appendChild(live);
-    }
+    var live = liveRegion();
+    if (!live) return;
+    clearTimeout(announceTimer);
     live.textContent = '';
-    /* Same string twice in a row is not re-announced; clearing first, on a
-       separate task, is what makes a second copy audible. */
-    setTimeout(function () { live.textContent = msg; }, 60);
+    /* Same string twice running is not re-announced; clearing first, on a
+       separate task, is what makes a second copy of the same control audible. */
+    announceTimer = setTimeout(function () { live.textContent = msg; }, 60);
   }
 
-  var flashed, flashTimer;
-  function flash(a) {
+  /* Two clicks in quick succession must not leave the chip naming a control that
+     is not the one on the clipboard — on the page whose whole subject is citing
+     the right one.
+
+     A token alone does not achieve that, and it is worth recording why, because
+     the first attempt here used one. A clipboard write crosses a process
+     boundary, so concurrent writes can land in any order: delay the first and
+     the second lands, then the first overwrites it. The clipboard then holds the
+     *older* control while a newest-click-wins token reports the newer one —
+     mislabelled, in the opposite direction from the race the token was guarding.
+
+     So the writes are serialised as well. Chained, the last write initiated is
+     also the last to land, which is the condition that makes the token correct.
+     A slow write delays the next one; that is the price, and it is invisible at
+     the speed a clipboard normally settles. */
+  var chain = Promise.resolve();
+  var seq = 0, flashed, flashTimer;
+  function report(a, id, mine) {
+    if (mine !== seq) return;
     clearTimeout(flashTimer);
     if (flashed) flashed.classList.remove('copied');
-    flashed = a;
-    a.classList.add('copied');
+    var cell = a.closest('.cidcell') || a;
+    flashed = cell;
+    cell.classList.add('copied');
+    announce(id + ' address copied');
     flashTimer = setTimeout(function () {
-      a.classList.remove('copied');
-      flashed = null;
+      cell.classList.remove('copied');
+      if (flashed === cell) flashed = null;
+      /* The chip clears itself; the region has to be cleared with it, or a
+         reader who later browses to the end of the document meets a stale
+         "copied" as page content. */
+      var live = liveRegion();
+      if (live) live.textContent = '';
     }, 1600);
   }
 
@@ -211,13 +254,27 @@
     var id = a.getAttribute('href').slice(1);
     if (!/^(?:DIS|CON|AUT|VAL|OBS|RES)-\d{2}$/.test(id)) return;
     if (!navigator.clipboard || !navigator.clipboard.writeText) return;
-    navigator.clipboard.writeText(citation(id)).then(function () {
-      flash(a);
-      announce(id + ' address copied');
+    var mine = ++seq;
+    chain = chain.then(function () {
+      return navigator.clipboard.writeText(citation(id));
+    }).then(function () {
+      report(a, id, mine);
+      /* Distinct from `control`, which fires on the click whether or not the
+         write succeeded. This one means an address actually reached a clipboard,
+         which is the closest thing to citation intent the page can observe. */
+      if (mine === seq && typeof va === 'function') {
+        va('event', { name: 'copy', data: { id: id } });
+      }
     }, function () {
-      /* Denied, or no permission in this context. The navigation already
-         happened, so the reader is no worse off than before — and nothing
-         claims a copy that did not occur. */
+      /* Denied, or an insecure context — a plain-http mirror or a saved copy.
+         The navigation already happened, so the reader is no worse off than
+         before, and nothing claims a copy that did not occur. Said out loud
+         because the page invites the click and silence here is indistinguishable
+         from success to anyone who cannot see the missing chip.
+
+         Returning nothing here keeps the chain alive: a rejection that is not
+         absorbed would poison every later click in the session. */
+      if (mine === seq) announce(id + ' could not be copied');
     });
   });
 

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -9,7 +9,15 @@
   addEventListener('DOMContentLoaded', function () {
     /* Landing directly on a control means someone was sent it, or cited it —
        the behaviour the whole versioning promise exists to support, and
-       invisible in page views because the hash never reaches the server. */
+       invisible in page views because the hash never reaches the server.
+
+       What this cannot see: a textual citation. The page's own prescribed form
+       is `DIS-01 (Agent Baseline v1.x)`, and a reader who meets that in an RFP
+       response has no link to follow — they search, land on /controls with no
+       hash, and this event does not fire even though the citation worked
+       perfectly. `arrival` counts linked citations only. A low number is not
+       evidence of low reach, in the same way `rsvp` reading zero would not have
+       been evidence nobody wanted to come. Read it as a floor. */
     var hash = (location.hash || '').slice(1);
     if (/^(?:DIS|CON|AUT|VAL|OBS|RES)-\d{2}$/.test(hash) && typeof va === 'function') {
       va('event', { name: 'arrival', data: { at: hash } });

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,12 @@
       ],
       "destination": "https://agentbaseline.org/$1",
       "permanent": true
+    },
+    {
+      "//": "VERSIONING.md and docs/decisions/0001 both prescribe agentbaseline.org/DIS-01 as a way to qualify an identifier by namespace. It has never resolved: there is no such route, cleanUrls sends it to the 404 page, and the promise has been in two documents since before this file had a redirect in it. This makes the documented form work. Not permanent: the resolvable address of a control is /controls#ID, and a 308 would let caches outlive a decision to serve these directly.",
+      "source": "/(DIS|CON|AUT|VAL|OBS|RES)-(\\d{2})",
+      "destination": "/controls#$1-$2",
+      "permanent": false
     }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,6 @@
       "permanent": true
     },
     {
-      "//": "VERSIONING.md and docs/decisions/0001 both prescribe agentbaseline.org/DIS-01 as a way to qualify an identifier by namespace. It has never resolved: there is no such route, cleanUrls sends it to the 404 page, and the promise has been in two documents since before this file had a redirect in it. This makes the documented form work. Not permanent: the resolvable address of a control is /controls#ID, and a 308 would let caches outlive a decision to serve these directly.",
       "source": "/(DIS|CON|AUT|VAL|OBS|RES)-(\\d{2})",
       "destination": "/controls#$1-$2",
       "permanent": false


### PR DESCRIPTION
The controls page teaches readers to cite a control as bare text — `DIS-01 (Agent Baseline v1.0-draft)` — while the `arrival` event fires only on a URL carrying `#DIS-01`. A reader who does exactly what the document asks produces no signal: they meet the identifier in a questionnaire, have no link to follow, search, and land on `/controls` with no hash. So the event cannot rise when citation succeeds, which means it cannot warn when citation fails either. Two halves close that. The clipboard serves the citer standing on the page: each identifier now copies its own absolute address, and a successful copy emits its own event, because otherwise the behaviour named as the motivation would go unmeasured in exactly the way `arrival` does. The redirect serves the reader stuck with an identifier: `VERSIONING.md` and ADR-0001 have both prescribed `agentbaseline.org/DIS-01` since before this repo's config had a redirect in it, and it has never resolved — `cleanUrls` sends it to the 404 page. Only the first half was built originally, which made the site the only one of four documents that answers "what is a control's address", while the answer two others give was broken.

Two constraints the code cannot state for itself. The copied address is the one the document declares as canonical rather than the origin it is served from, and it is assembled through `URL` rather than by trimming a string, because stripping a trailing slash off a root canonical also strips the path. And the clipboard writes are serialised, not merely tokenised: writes cross a process boundary and can land out of order, so a token alone let the chip name the newer control while the older one sat on the clipboard — mislabelled in the opposite direction from the race the token was added to fix. On the gate side, `bin/check-controls` now asserts the *shape* of `baseURL` rather than its value; pinning the domain would fight the promise that identifiers survive a transfer to a community body.

Still wrong after this lands, or worth knowing. `arrival` sees linked citations only and can also be crossed by a link to a control that is not on the page, so it stays a floor — `copy` is the leading indicator worth watching instead. Nothing drives a browser in CI, so every claim about click behaviour rests on review rather than a check that re-runs; `bin/check-pdf-current` explains why a browser gate is not on the table here. The three commits after the first two are repairs to things five blind reviewers found in the original attempt, including one blocking accessibility defect that made the page worse than `main` on arrival — the commit messages carry the detail. Two of those commits fix pre-existing holes rather than my own: a gate that reported success without running, and a derived figure the reader sees that had no drift check.